### PR TITLE
Add afterCreate hook

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+*.md
+node_modules/

--- a/README.md
+++ b/README.md
@@ -22,25 +22,35 @@ yarn add git+ssh://git@github.com/thoughtbot/fishery
 
 It is generally recommended to define one factory per file and then combine them together to form a `factories` object which can then be used in tests, Storybook, etc.:
 
+### Define factories
+
 ```typescript
 // factories/user.ts
 import { Factory } from 'fishery';
 import { User } from '../types';
 
 export default Factory.define<User>(({ sequence }) => ({
-  id: `user-${sequence}`,
+  id: sequence,
   name: 'Bob',
 }));
 ```
 
+### Combine factories
+
+This step is optional and is just for convenience.
+
 ```typescript
 // factories/index.ts
 import user from './user';
+import post from './post';
 
 export const factories = {
   user,
+  post,
 };
 ```
+
+### Use factories
 
 ```typescript
 // my-test.test.ts
@@ -57,24 +67,42 @@ Factories are typed, so using the factory from the above example, these would bo
 
 ```typescript
 const user = factories.user.build();
-user.email; // type error! Property 'email' does not exist on type 'User'
+user.foo; // type error! Property 'foo' does not exist on type 'User'
 ```
 
 ```typescript
-const user = factories.user.build({ age: 18 }); // type error! Argument of type '{ age: number; }' is not assignable to parameter of type 'Partial<User>'.
+const user = factories.user.build({ foo: 'bar' }); // type error! Argument of type '{ foo: string; }' is not assignable to parameter of type 'Partial<User>'.
+```
+
+### After-create hook
+
+You can instruct factories to execute some code after an object is created:
+
+```typescript
+export default Factory.define<User>(({ sequence, afterCreate }) => {
+  // TypeScript knows the type of `user` here 🎉
+  afterCreate(user => {
+    user.name = 'Susan';
+  });
+
+  return {
+    id: sequence,
+    name: 'Bob',
+  };
+});
 ```
 
 ### Associations
 
-TODO
+Coming soon...
 
 ## Contributing
 
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
-  [CONTRIBUTING]: CONTRIBUTING.md
-  [contributors]: https://github.com/thoughtbot/templates/graphs/contributors
+[CONTRIBUTING]: CONTRIBUTING.md
+[contributors]: https://github.com/thoughtbot/templates/graphs/contributors
 
 ## Credits
 

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -1,4 +1,5 @@
 import { Factory } from '../factory';
+import { HookFn } from '../types';
 
 type User = {
   id: string;
@@ -27,5 +28,47 @@ describe('factory.buildList', () => {
     expect(users.length).toBe(2);
     expect(users[0].id).not.toEqual(users[1].id);
     expect(users.map(u => u.name)).toEqual(['susan', 'susan']);
+  });
+
+  it('calls afterCreate for each item', () => {
+    const afterCreateFn = jest.fn(user => {
+      user.name = 'Bill';
+    });
+
+    const factory = Factory.define<User>(({ afterCreate }) => {
+      afterCreate(afterCreateFn);
+
+      return { id: '1', name: 'Ralph' };
+    });
+
+    expect(factory.buildList(2).every(u => u.name === 'Bill')).toBeTruthy();
+    expect(afterCreateFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('afterCreate', () => {
+  it('passes the object for manipulation', () => {
+    const factory = Factory.define<User>(({ afterCreate }) => {
+      afterCreate(user => {
+        user.id = 'bla';
+      });
+
+      return { id: '1', name: 'Ralph' };
+    });
+
+    expect(factory.build().id).toEqual('bla');
+  });
+
+  describe('when not a function', () => {
+    it('raises an error', () => {
+      const factory = Factory.define<User>(({ afterCreate }) => {
+        afterCreate(('5' as unknown) as HookFn<User>);
+        return { id: '1', name: 'Ralph' };
+      });
+
+      expect(() => {
+        factory.build();
+      }).toThrowError(/must be a function/);
+    });
   });
 });

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,0 +1,40 @@
+import { GeneratorFn, HookFn, GeneratorFnOptions } from './types';
+
+export class FactoryBuilder<T> {
+  private afterCreate?: HookFn<T>;
+  constructor(
+    private generator: GeneratorFn<T>,
+    private sequence: number,
+    private params: Partial<T>,
+  ) {}
+
+  build() {
+    const generatorOptions: GeneratorFnOptions<T> = {
+      sequence: this.sequence,
+      afterCreate: this.setAfterCreate,
+      params: this.params,
+    };
+
+    const object: T = {
+      ...this.generator(generatorOptions),
+      ...this.params,
+    };
+
+    this._callAfterCreate(object);
+    return object;
+  }
+
+  setAfterCreate = (hook: HookFn<T>) => {
+    this.afterCreate = hook;
+  };
+
+  _callAfterCreate(object: T) {
+    if (this.afterCreate) {
+      if (typeof this.afterCreate === 'function') {
+        this.afterCreate(object);
+      } else {
+        throw new Error('"afterCreate" must be a function');
+      }
+    }
+  }
+}

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -1,30 +1,23 @@
-export type GeneratorFnOptions = {
-  sequence: number;
-};
-export type GeneratorFn<T> = (opts: GeneratorFnOptions) => T;
-
-let id = 1;
-const nextId = () => id++;
+import { GeneratorFn } from './types';
+import { FactoryBuilder } from './builder';
 
 export class Factory<T> {
-  generator: GeneratorFn<T>;
-
-  constructor(generator: GeneratorFn<T>) {
-    this.generator = generator;
-  }
+  nextId: number = 0;
+  constructor(private generator: GeneratorFn<T>) {}
 
   static define<T>(generator: GeneratorFn<T>) {
     return new Factory<T>(generator);
   }
 
-  build(options: Partial<T>): T {
-    return {
-      ...this.generator({ sequence: nextId() }),
-      ...options,
-    };
+  build(options: Partial<T> = {}): T {
+    return new FactoryBuilder<T>(
+      this.generator,
+      this.nextId++,
+      options,
+    ).build();
   }
 
-  buildList(number: number, options: Partial<T>): T[] {
+  buildList(number: number, options: Partial<T> = {}): T[] {
     let list: T[] = [];
     for (let i = 0; i < number; i++) {
       list.push(this.build(options));

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './factory';
+export * from './types';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,7 @@
+export type GeneratorFnOptions<T> = {
+  sequence: number;
+  afterCreate: (fn: HookFn<T>) => any;
+  params: Partial<T>;
+};
+export type GeneratorFn<T> = (opts: GeneratorFnOptions<T>) => T;
+export type HookFn<T> = (object: T) => any;


### PR DESCRIPTION
This adds an `afterCreate` hook that can be defined in factories.

Also:

* Refactor factory to have separate Builder class
* Update readme examples
* Change nextId to calculate in each factory instance