### PR TITLE
Clean up imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,7 @@ module.exports = {
   rootDir: './',
   testEnvironment: 'node',
   testMatch: ['**/lib/**/__tests__/*.+(ts|tsx|js)'],
+  moduleNameMapper: {
+    fishery: '<rootDir>/lib/index',
+  },
 };

--- a/lib/__tests__/associations.test.ts
+++ b/lib/__tests__/associations.test.ts
@@ -1,6 +1,4 @@
-import { Factory } from '../factory';
-import { HookFn } from '../types';
-import { register } from '../register';
+import { Factory, HookFn, register } from 'fishery';
 
 interface Post {
   title: string;

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -1,6 +1,4 @@
-import { Factory } from '../factory';
-import { HookFn } from '../types';
-import { register } from '../register';
+import { register, Factory, HookFn } from 'fishery';
 
 type User = {
   id: string;

--- a/lib/__tests__/sample-app/factories/index.ts
+++ b/lib/__tests__/sample-app/factories/index.ts
@@ -1,6 +1,6 @@
 import user from './user';
 import post from './post';
-import { register } from '../../../register';
+import { register } from 'fishery';
 import { Factories } from '../types';
 
 export const factories: Factories = {

--- a/lib/__tests__/sample-app/factories/post.ts
+++ b/lib/__tests__/sample-app/factories/post.ts
@@ -1,6 +1,5 @@
-import { Factory } from '../../../factory';
+import { Factory } from 'fishery';
 import { Post, Factories } from '../types';
-import user from './user';
 
 export default Factory.define<Post, Factories>(
   ({ sequence, params, instance, factories }) => ({

--- a/lib/__tests__/sample-app/factories/user.ts
+++ b/lib/__tests__/sample-app/factories/user.ts
@@ -1,4 +1,4 @@
-import { Factory } from '../../../factory';
+import { Factory } from 'fishery';
 import { User, Factories } from '../types';
 
 export default Factory.define<User, Factories>(

--- a/lib/__tests__/sample-app/types.ts
+++ b/lib/__tests__/sample-app/types.ts
@@ -1,4 +1,4 @@
-import { Factory } from '../../factory';
+import { Factory } from 'fishery';
 
 export interface Factories {
   user: Factory<User>;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
-export * from './factory';
 export * from './types';
+export * from './factory';
+export * from './register';

--- a/lib/register.ts
+++ b/lib/register.ts
@@ -1,4 +1,4 @@
-import { Factory, AnyFactories } from './factory';
+import { AnyFactories } from './factory';
 
 // TODO: would like to type this argument as AnyFactories but issue with
 // inheritance since user-defined Factories will not have index property set

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
     "outDir": "./dist",
     "strict": true,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "fishery": ["lib/index"]
+    }
   }
 }


### PR DESCRIPTION
Adds paths to `tsconfig.json` and jest `moduleNameMapper` so we can import lib modules through `index.ts` using `import { xx } from 'fishery'`. 

This helps ensure we are exporting everything correctly, since our tests are now using the library in the same way as users of the library.