### PR TITLE
Clean up associations - no longer use `instance`

### DIFF
--- a/lib/__tests__/associations.test.ts
+++ b/lib/__tests__/associations.test.ts
@@ -4,6 +4,7 @@ interface Post {
   title: string;
   user: User;
 }
+
 interface User {
   name: string;
   posts: Array<Post>;
@@ -28,18 +29,21 @@ describe('associations', () => {
     factory.build();
   });
 
-  it('can create inverse associations', () => {
+  it('can create simple has-many/belongs-to associations', () => {
     const userFactory = Factory.define<User, Factories>(
-      ({ factories, instance }) => ({
-        name: 'Bob',
-        posts: [factories.post.build({ user: instance })],
-      }),
+      ({ factories, afterCreate }) => {
+        afterCreate(user => user.posts.push(factories.post.build({ user })));
+        return {
+          name: 'Bob',
+          posts: [],
+        };
+      },
     );
 
     const postFactory = Factory.define<Post, Factories>(
-      ({ factories, instance, params }) => ({
+      ({ factories, params }) => ({
         title: 'A Post',
-        user: params.user || factories.user.build({ posts: [instance] }),
+        user: params.user || factories.user.build(),
       }),
     );
 

--- a/lib/__tests__/class-factories.test.ts
+++ b/lib/__tests__/class-factories.test.ts
@@ -1,0 +1,25 @@
+import { Factory, HookFn, register } from 'fishery';
+
+describe('Using with classes', () => {
+  it('works correctly with read-only properties', () => {
+    class User {
+      constructor(readonly name: string) {}
+      greet() {
+        return `Hello, ${this.name}`;
+      }
+    }
+
+    const userFactory = Factory.define<User>(() => new User('Sharon'));
+
+    register({
+      user: userFactory,
+    });
+
+    const user = userFactory.build();
+    expect(user).toBeInstanceOf(User);
+    expect(user.greet()).toEqual('Hello, Sharon');
+    expect(userFactory.build({ name: 'Bob' }).name).toEqual('Bob');
+  });
+
+  // TODO: show that doesn't allow private properties (feature or bug?)
+});

--- a/lib/__tests__/factory-sample-app.test.ts
+++ b/lib/__tests__/factory-sample-app.test.ts
@@ -7,12 +7,3 @@ describe('Factory.build', () => {
     expect(user.name).toEqual('susan');
   });
 });
-
-describe('Associations', () => {
-  it('works, recursively', () => {
-    const user = factories.user.build();
-    expect(user.post).not.toBeNull();
-    expect(user.post.title).toEqual('A Post');
-    expect(user.post.user).toEqual(user);
-  });
-});

--- a/lib/__tests__/sample-app/factories/index.ts
+++ b/lib/__tests__/sample-app/factories/index.ts
@@ -3,11 +3,9 @@ import post from './post';
 import { register } from 'fishery';
 import { Factories } from '../types';
 
-export const factories: Factories = {
+export const factories: Factories = register({
   user,
   post,
-};
-
-register(factories);
+});
 
 export { user, post };

--- a/lib/__tests__/sample-app/factories/post.ts
+++ b/lib/__tests__/sample-app/factories/post.ts
@@ -2,9 +2,9 @@ import { Factory } from 'fishery';
 import { Post, Factories } from '../types';
 
 export default Factory.define<Post, Factories>(
-  ({ sequence, params, instance, factories }) => ({
+  ({ sequence, params, factories }) => ({
     id: sequence,
     title: 'A Post',
-    user: params.user || factories.user.build({ post: instance }),
+    user: params.user || factories.user.build(),
   }),
 );

--- a/lib/__tests__/sample-app/factories/user.ts
+++ b/lib/__tests__/sample-app/factories/user.ts
@@ -1,10 +1,10 @@
 import { Factory } from 'fishery';
 import { User, Factories } from '../types';
 
-export default Factory.define<User, Factories>(
-  ({ sequence, params, instance, factories }) => ({
+export default Factory.define<User, Factories>(({ sequence }) => {
+  return {
     id: `user-${sequence}`,
     name: 'Bob',
-    post: params.post || factories.post.build({ user: instance }),
-  }),
-);
+    post: null,
+  };
+});

--- a/lib/__tests__/sample-app/types.ts
+++ b/lib/__tests__/sample-app/types.ts
@@ -8,11 +8,11 @@ export interface Factories {
 export interface User {
   id: string;
   name: string;
-  post: Post;
+  post: Post | null;
 }
 
 export interface Post {
   id: number;
   title: string;
-  user?: User;
+  user: User | null;
 }

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -10,22 +10,15 @@ export class FactoryBuilder<T, F> {
   ) {}
 
   build() {
-    const object = {} as T; // kinda lying. Might be a problem
     const generatorOptions: GeneratorFnOptions<T, F> = {
       sequence: this.sequence,
       afterCreate: this.setAfterCreate,
       factories: this.factories,
-      instance: object,
       params: this.params,
     };
 
-    const tmpObject: T = {
-      ...this.generator(generatorOptions),
-      ...this.params,
-    };
-
-    Object.assign(object, tmpObject);
-
+    const object = this.generator(generatorOptions);
+    Object.assign(object, this.params);
     this._callAfterCreate(object);
     return object;
   }

--- a/lib/register.ts
+++ b/lib/register.ts
@@ -3,9 +3,11 @@ import { AnyFactories } from './factory';
 // TODO: would like to type this argument as AnyFactories but issue with
 // inheritance since user-defined Factories will not have index property set
 // see: https://github.com/Microsoft/TypeScript/issues/15300
-export const register = (allFactories: object) => {
+export const register = <T extends object>(allFactories: T) => {
   const factories = allFactories as AnyFactories;
   Object.keys(factories).forEach((key: string) => {
     factories[key].factories = factories;
   });
+
+  return allFactories;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,6 @@ export type GeneratorFnOptions<T, F> = {
   sequence: number;
   afterCreate: (fn: HookFn<T>) => any;
   params: Partial<T>;
-  instance: T;
   factories: F;
 };
 export type GeneratorFn<T, F> = (opts: GeneratorFnOptions<T, F>) => T;


### PR DESCRIPTION
* [x] TODO: Update readme

Previously, we were allowing factories to set up recursive associations. Eg. User has many posts and Post has many users. We were enabling this by passing in an `instance` property that factories could use to reference themselves for passing into relationships. This was problematic, though, since the instance object wasn't actually an instance of the specified class. It was just a dummy object that we were instantiating and then later filling in (after the association was created). 

The main problems with this were:

* This wouldn't work with object types that were not object literals, since the dummy object was not an instance of the class
* The dummy object wasn't a real object of the specified type, so if factories tried to use this object, things would break

To fix this, I removed the `instance` param, and if factories want to set up associations, they should ensure they are not recursive. This means it is now a little tricker to set up a belongs-to <-> belongs-to, but is that even a thing, so much?