### PR TITLE
Support transient parameters

### DIFF
--- a/lib/__tests__/input-type.test.ts
+++ b/lib/__tests__/input-type.test.ts
@@ -1,0 +1,70 @@
+import { Factory, HookFn, register } from 'fishery';
+import { factories } from './sample-app/factories';
+
+describe('Input types', () => {
+  interface User {
+    firstName: string;
+    lastName: string;
+    address: { city: string; state: string; country: string };
+  }
+
+  interface UserTransientParams {
+    city: string;
+    state: string;
+    country: string;
+    name: string;
+  }
+
+  const userFactory = Factory.define<User, any, UserTransientParams>(
+    ({ transientParams }) => {
+      const {
+        name = 'Sharon Jones',
+        city = 'Grand Rapids',
+        state = 'MI',
+        country = 'USA',
+      } = transientParams;
+
+      const [firstName, lastName] = name.split(' ');
+
+      return {
+        firstName,
+        lastName,
+        address: {
+          city,
+          state,
+          country,
+        },
+      };
+    },
+  );
+
+  const factories = register({
+    user: userFactory,
+  });
+
+  it('uses default when no transient param passed', () => {
+    const user = factories.user.build();
+    expect(user.address.country).toEqual('USA');
+  });
+
+  it('allows specifying different input type than output type', () => {
+    const userUSA = factories.user.build(null, { state: 'IL' });
+    expect(userUSA.address.state).toEqual('IL');
+  });
+
+  it('does not copy the input type properties to the built object', () => {
+    const user = factories.user.build(null, { country: 'USA' });
+    expect((user as any).country).toBeUndefined();
+  });
+
+  it('can override transient params with regular params', () => {
+    const user = factories.user.build(
+      { firstName: 'Sue' },
+      { name: 'Joe Smith' },
+    );
+    expect(user).toMatchObject({
+      firstName: 'Sue',
+      lastName: 'Smith',
+    });
+  });
+});

--- a/lib/__tests__/transient-params.test.ts
+++ b/lib/__tests__/transient-params.test.ts
@@ -1,7 +1,6 @@
 import { Factory, HookFn, register } from 'fishery';
-import { factories } from './sample-app/factories';
 
-describe('Input types', () => {
+describe('Transient params', () => {
   interface User {
     firstName: string;
     lastName: string;
@@ -47,24 +46,34 @@ describe('Input types', () => {
     expect(user.address.country).toEqual('USA');
   });
 
-  it('allows specifying different input type than output type', () => {
-    const userUSA = factories.user.build(null, { state: 'IL' });
+  it('overrides default when passed', () => {
+    const userUSA = factories.user.build({}, { transient: { state: 'IL' } });
     expect(userUSA.address.state).toEqual('IL');
   });
 
-  it('does not copy the input type properties to the built object', () => {
-    const user = factories.user.build(null, { country: 'USA' });
+  it('does not copy the transient params to the built object', () => {
+    const user = factories.user.build({}, { transient: { country: 'USA' } });
     expect((user as any).country).toBeUndefined();
   });
 
   it('can override transient params with regular params', () => {
     const user = factories.user.build(
       { firstName: 'Sue' },
-      { name: 'Joe Smith' },
+      { transient: { name: 'Joe Smith' } },
     );
     expect(user).toMatchObject({
       firstName: 'Sue',
       lastName: 'Smith',
     });
+  });
+
+  it('works with buildList', () => {
+    const users = factories.user.buildList(
+      1,
+      {},
+      { transient: { city: 'Detroit' } },
+    );
+
+    expect(users[0].address.city).toEqual('Detroit');
   });
 });

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,20 +1,25 @@
 import { GeneratorFn, HookFn, GeneratorFnOptions } from './types';
 
-export class FactoryBuilder<T, F> {
+export class FactoryBuilder<T, F, I> {
   private afterCreate?: HookFn<T>;
+  private params: Partial<T>;
   constructor(
-    private generator: GeneratorFn<T, F>,
+    private generator: GeneratorFn<T, F, I>,
     private factories: F,
     private sequence: number,
-    private params: Partial<T>,
-  ) {}
+    params: Partial<T> | null,
+    private transientParams: Partial<I>,
+  ) {
+    this.params = params || {};
+  }
 
   build() {
-    const generatorOptions: GeneratorFnOptions<T, F> = {
+    const generatorOptions: GeneratorFnOptions<T, F, I> = {
       sequence: this.sequence,
       afterCreate: this.setAfterCreate,
       factories: this.factories,
       params: this.params,
+      transientParams: this.transientParams,
     };
 
     const object = this.generator(generatorOptions);

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -2,16 +2,13 @@ import { GeneratorFn, HookFn, GeneratorFnOptions } from './types';
 
 export class FactoryBuilder<T, F, I> {
   private afterCreate?: HookFn<T>;
-  private params: Partial<T>;
   constructor(
     private generator: GeneratorFn<T, F, I>,
     private factories: F,
     private sequence: number,
-    params: Partial<T> | null,
+    private params: Partial<T>,
     private transientParams: Partial<I>,
-  ) {
-    this.params = params || {};
-  }
+  ) {}
 
   build() {
     const generatorOptions: GeneratorFnOptions<T, F, I> = {

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -5,35 +5,40 @@ export interface AnyFactories {
   [key: string]: Factory<any>;
 }
 
-export class Factory<T, F = any> {
+export class Factory<T, F = any, I = any> {
   nextId: number = 0;
   factories?: F;
 
-  constructor(private generator: GeneratorFn<T, F>) {}
+  constructor(private generator: GeneratorFn<T, F, I>) {}
 
-  static define<T, F = any>(generator: GeneratorFn<T, F>) {
-    return new Factory<T, F>(generator);
+  static define<T, F = any, I = any>(generator: GeneratorFn<T, F, I>) {
+    return new Factory<T, F, I>(generator);
   }
 
-  build(options: Partial<T> = {}): T {
+  build(params: Partial<T> | null = {}, transientParams: Partial<I> = {}): T {
     if (!this.factories) {
       throw new Error(
         'Factories have not been registered. Call `register` before using factories',
       );
     }
 
-    return new FactoryBuilder<T, F>(
+    return new FactoryBuilder<T, F, I>(
       this.generator,
       this.factories,
       this.nextId++,
-      options,
+      params,
+      transientParams,
     ).build();
   }
 
-  buildList(number: number, options: Partial<T> = {}): T[] {
+  buildList(
+    number: number,
+    params: Partial<T> | null = {},
+    transientParams: Partial<I> = {},
+  ): T[] {
     let list: T[] = [];
     for (let i = 0; i < number; i++) {
-      list.push(this.build(options));
+      list.push(this.build(params, transientParams));
     }
 
     return list;

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -1,4 +1,4 @@
-import { GeneratorFn } from './types';
+import { GeneratorFn, BuildOptions } from './types';
 import { FactoryBuilder } from './builder';
 
 export interface AnyFactories {
@@ -15,7 +15,10 @@ export class Factory<T, F = any, I = any> {
     return new Factory<T, F, I>(generator);
   }
 
-  build(params: Partial<T> | null = {}, transientParams: Partial<I> = {}): T {
+  build(
+    params: Partial<T> = {},
+    options: BuildOptions<I> = { transient: {} },
+  ): T {
     if (!this.factories) {
       throw new Error(
         'Factories have not been registered. Call `register` before using factories',
@@ -27,18 +30,18 @@ export class Factory<T, F = any, I = any> {
       this.factories,
       this.nextId++,
       params,
-      transientParams,
+      options.transient,
     ).build();
   }
 
   buildList(
     number: number,
-    params: Partial<T> | null = {},
-    transientParams: Partial<I> = {},
+    params: Partial<T> = {},
+    options: BuildOptions<I> = { transient: {} },
   ): T[] {
     let list: T[] = [];
     for (let i = 0; i < number; i++) {
-      list.push(this.build(params, transientParams));
+      list.push(this.build(params, options));
     }
 
     return list;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,8 +1,9 @@
-export type GeneratorFnOptions<T, F> = {
+export type GeneratorFnOptions<T, F, I> = {
   sequence: number;
   afterCreate: (fn: HookFn<T>) => any;
-  params: Partial<T>;
+  params: Partial<T> | null;
+  transientParams: Partial<I>;
   factories: F;
 };
-export type GeneratorFn<T, F> = (opts: GeneratorFnOptions<T, F>) => T;
+export type GeneratorFn<T, F, I> = (opts: GeneratorFnOptions<T, F, I>) => T;
 export type HookFn<T> = (object: T) => any;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,12 @@
 export type GeneratorFnOptions<T, F, I> = {
   sequence: number;
   afterCreate: (fn: HookFn<T>) => any;
-  params: Partial<T> | null;
+  params: Partial<T>;
   transientParams: Partial<I>;
   factories: F;
 };
 export type GeneratorFn<T, F, I> = (opts: GeneratorFnOptions<T, F, I>) => T;
 export type HookFn<T> = (object: T) => any;
+export type BuildOptions<I> = {
+  transient: Partial<I>;
+};


### PR DESCRIPTION
Resolves: https://trello.com/c/CLRRqF3z/11-allow-separately-specifying-input-type-and-output-type

This adds support for factory input being different from the output object. The `factory.build` function is typed so that the params object that is passed has to be a partial of the return object -- if any params that aren't in the return object were passed, a compile error would show.

There are cases, however, when it might be desirable to pass arbitrary data to a factory for use in constructing an object. This adds a second argument to `factory.build` that accepts a `transient` key that includes arbitrary params that can be used by the factory and aren't in the output object.

Here is the new Readme section on this with more info: https://github.com/thoughtbot/fishery/tree/transient-params#params-that-dont-map-to-the-result-object-transient-params