### PR TITLE
Use deep merge when overlaying params onto factory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
-*.md
+dist/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export default Factory.define<User>(({ sequence, factories }) => ({
   id: sequence,
   name: 'Bob',
   address: { city: 'Grand Rapids', state: 'MI', country: 'USA' },
-  posts: factories.post.buildList(2)
+  posts: factories.post.buildList(2),
 }));
 ```
 
@@ -66,21 +66,21 @@ Pass parameters as the first argument to `build` to override your factory defaul
 
 `build` also supports a seconds argument with the following keys:
 
-* `transient`: data for use in your factory that doesn't get overlaid onto your result object. More on this in the [Transient Params](#params-that-dont-map-to-the-result-object-transient-params) section
-* `associations`: often not required but can be useful in the case of bi-directional associations. More on this in the [Associations](#Associations) section
+- `transient`: data for use in your factory that doesn't get overlaid onto your result object. More on this in the [Transient Params](#params-that-dont-map-to-the-result-object-transient-params) section
+- `associations`: often not required but can be useful in the case of bi-directional associations. More on this in the [Associations](#Associations) section
 
 ```typescript
 // my-test.test.ts
 import { factories } from './factories';
 
 const user = factories.user.build({
-  name: "Susan",
-  address: { city: "Detroit" }
+  name: 'Susan',
+  address: { city: 'Detroit' },
 });
 
-user.name          // Susan
-user.address.city  // Detroit
-user.address.state // MI (from factory)
+user.name; // Susan
+user.address.city; // Detroit
+user.address.state; // MI (from factory)
 ```
 
 ## Documentation
@@ -101,13 +101,13 @@ const user = factories.user.build({ foo: 'bar' }); // type error! Argument of ty
 ```typescript
 export default Factory.define<User, Factories, UserTransientParams>(
   ({ sequence, params, transientParams, associations, afterCreate }) => {
-    params.firstName    // Property 'firstName' does not exist on type 'DeepPartial<User>
-    transientParams.foo // Property 'foo' does not exist on type 'Partial<UserTransientParams>'
-    associations.bar    // Property 'bar' does not exist on type 'Partial<User>'
+    params.firstName; // Property 'firstName' does not exist on type 'DeepPartial<User>
+    transientParams.foo; // Property 'foo' does not exist on type 'Partial<UserTransientParams>'
+    associations.bar; // Property 'bar' does not exist on type 'Partial<User>'
 
     afterCreate(user => {
-      user.foo // Property 'foo' does not exist on type 'User'
-    })
+      user.foo; // Property 'foo' does not exist on type 'User'
+    });
 
     return {
       id: `user-${sequence}`,
@@ -124,12 +124,10 @@ If your factory references another factory, use the `factories` object
 provided to the factory:
 
 ```typescript
-const postFactory = Factory.define<Post, Factories>(
-  ({ factories }) => ({
-    title: 'My Blog Post',
-    author: factories.user.build(),
-  }),
-);
+const postFactory = Factory.define<Post, Factories>(({ factories }) => ({
+  title: 'My Blog Post',
+  author: factories.user.build(),
+}));
 ```
 
 If you'd like to be able to pass in an association when building your object and short-circuit the call to `factories.xxx.build()`, use the `associations` variable provided to your factory:
@@ -146,7 +144,7 @@ const postFactory = Factory.define<Post, Factories>(
 Then build your object like this:
 
 ```typescript
-factories.post.build({}, { associations: { author: susan }})
+factories.post.build({}, { associations: { author: susan } });
 ```
 
 #### Typing the `factories` factory argument
@@ -185,18 +183,16 @@ explicitly access the params in your factory. This can, however, be useful,
 for example, if your factory uses the params to compute other properties:
 
 ```typescript
-const userFactory = Factory.define<User, Factories>(
-  ({ params }) => {
-    const { name = 'Bob Smith' } = params;
-    const email = params.email || `${kebabCase(name)}@example.com`;
+const userFactory = Factory.define<User, Factories>(({ params }) => {
+  const { name = 'Bob Smith' } = params;
+  const email = params.email || `${kebabCase(name)}@example.com`;
 
-    return {
-      name,
-      email,
-      posts: [],
-    };
-  },
-);
+  return {
+    name,
+    email,
+    posts: [],
+  };
+});
 ```
 
 ### Params that don't map to the result object (transient params)
@@ -237,7 +233,7 @@ const userFactory = Factory.define<User, Factories, UserTransientParams>(
         canPost: registered,
       },
     };
-  }
+  },
 );
 ```
 
@@ -252,10 +248,10 @@ precedence over the transient params:
 ```typescript
 const user = factories.user.build(
   { memberId: '1' },
-  { transient: { registered: true } }
+  { transient: { registered: true } },
 );
-user.memberId // '1'
-user.permissions.canPost  // true
+user.memberId; // '1'
+user.permissions.canPost; // true
 ```
 
 ### After-create hook
@@ -286,7 +282,7 @@ export default Factory.define<User, Factories>(
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
-[CONTRIBUTING]: CONTRIBUTING.md
+[contributing]: CONTRIBUTING.md
 [contributors]: https://github.com/thoughtbot/templates/graphs/contributors
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [![CircleCI](https://circleci.com/gh/thoughtbot/fishery.svg?style=svg)](https://circleci.com/gh/thoughtbot/fishery)
 
-**This project is still in early stages. Prior to a 1.0 release, its API is subject to change without notice.**
+Fishery is a library for setting up JavaScript objects for use in tests,
+Storybook, and anywhere else you need to set up data. It is loosely modeled
+after the Ruby gem, [factory_bot][factory_bot].
 
-Fishery is a library for setting up JavaScript objects for use in tests, Storybook, and anywhere else you need to set up data. It is modeled after the Ruby gem, [factory_bot][factory_bot].
-
-Fishery is built with TypeScript in mind. Factories return typed objects, so you can be confident that the data used in your tests is valid. If you aren't using TypeScript, that's fine too – Fishery still works, just without the extra typechecking that comes with TypeScript.
+Fishery is built with TypeScript in mind. Factories accept typed parameters and return typed objects, so you can be confident that the data used in your tests is valid. If you aren't using TypeScript, that's fine too – Fishery still works, just without the extra typechecking that comes with TypeScript.
 
 ## Installation
 
-First, install fishery with:
+Install fishery with:
 
 ```
 npm install --save fishery
@@ -24,7 +24,10 @@ yarn add fishery
 
 ## Usage
 
-It is recommended to define one factory per file and then combine them together to form a `factories` object which can then be used in tests, Storybook, etc.:
+A factory is just a function that returns your object. Fishery provides
+several arguments to your factory function to help with common situations.
+After defining your factory, you can then call `build()` on it to build your
+objects. Here's how it's done:
 
 ### Define factories
 
@@ -33,9 +36,11 @@ It is recommended to define one factory per file and then combine them together 
 import { Factory } from 'fishery';
 import { User } from '../my-types';
 
-export default Factory.define<User>(({ sequence }) => ({
+export default Factory.define<User>(({ sequence, factories }) => ({
   id: sequence,
   name: 'Bob',
+  address: { city: 'Grand Rapids', state: 'MI', country: 'USA' },
+  posts: factories.post.buildList(2)
 }));
 ```
 
@@ -55,20 +60,34 @@ export const factories = register({
 });
 ```
 
-### Use factories
+### Build objects with your factories
+
+Pass parameters as the first argument to `build` to override your factory defaults. These parameters are deep-merged into the default object returned by your factory.
+
+`build` also supports a seconds argument with the following keys:
+
+* `transient`: data for use in your factory that doesn't get overlaid onto your result object. More on this in the [Transient Params](#params-that-dont-map-to-the-result-object-transient-params) section
+* `associations`: often not required but can be useful in the case of bi-directional associations. More on this in the [Associations](#Associations) section
 
 ```typescript
 // my-test.test.ts
 import { factories } from './factories';
 
-const user = factories.user.build({ name: 'Susan' });
+const user = factories.user.build({
+  name: "Susan",
+  address: { city: "Detroit" }
+});
+
+user.name          // Susan
+user.address.city  // Detroit
+user.address.state // MI (from factory)
 ```
 
 ## Documentation
 
 ### Typechecking
 
-Factories are typed, so the following would cause TypeScript compile errors if using the factory defined above:
+Factories are fully typed, both when defining your factories and when using them to build objects, so you can be confident the data you are working with is correct.
 
 ```typescript
 const user = factories.user.build();
@@ -79,25 +98,65 @@ user.foo; // type error! Property 'foo' does not exist on type 'User'
 const user = factories.user.build({ foo: 'bar' }); // type error! Argument of type '{ foo: string; }' is not assignable to parameter of type 'Partial<User>'.
 ```
 
+```typescript
+export default Factory.define<User, Factories, UserTransientParams>(
+  ({ sequence, params, transientParams, associations, afterCreate }) => {
+    params.firstName    // Property 'firstName' does not exist on type 'DeepPartial<User>
+    transientParams.foo // Property 'foo' does not exist on type 'Partial<UserTransientParams>'
+    associations.bar    // Property 'bar' does not exist on type 'Partial<User>'
+
+    afterCreate(user => {
+      user.foo // Property 'foo' does not exist on type 'User'
+    })
+
+    return {
+      id: `user-${sequence}`,
+      name: 'Bob',
+      post: null,
+    };
+  },
+);
+```
+
 ### Associations
 
 If your factory references another factory, use the `factories` object
-provided by the generator function:
+provided to the factory:
 
 ```typescript
 const postFactory = Factory.define<Post, Factories>(
-  ({ factories, params }) => ({
+  ({ factories }) => ({
     title: 'My Blog Post',
     author: factories.user.build(),
   }),
 );
 ```
 
-In the above example, the `Factories` generic parameter is passed to
-`define`. This is optional but recommended in order to get type-checking of
-the `factories` object. You can define your `Factories` object like this:
+If you'd like to be able to pass in an association when building your object and short-circuit the call to `factories.xxx.build()`, use the `associations` variable provided to your factory:
 
 ```typescript
+const postFactory = Factory.define<Post, Factories>(
+  ({ factories, associations }) => ({
+    title: 'My Blog Post',
+    author: associations.author || factories.user.build(),
+  }),
+);
+```
+
+Then build your object like this:
+
+```typescript
+factories.post.build({}, { associations: { author: susan }})
+```
+
+#### Typing the `factories` factory argument
+
+In the above examples, the `Factories` generic parameter is passed to
+`define`. This is optional but recommended in order to get type-checking of
+the `factories` object. You can define your `Factories` type like this:
+
+```typescript
+// factories/types.ts
 export interface Factories {
   user: Factory<User>;
   post: Factory<Post>;
@@ -118,25 +177,27 @@ import { Factories } from './types';
 export const factories: Factories = register({ user, post });
 ```
 
-#### Use `params` to access passed in properties
+### Use `params` to access passed in properties
 
-In the above `postsfactory` example, the author property is calculated as `author: params.author || factories.user.build()`. The `params` object represents the properties bassed to the factory's `build` method. With this definition, if we create a post with `postsFactory.build({ author })`, then `factories.user.build()` is conveniently not executed. This can be handy in preventing infinite loops or expensive operations. 
-
-It is important to note that if the user factory has a call to `factories.post.build()` (without specifying the author), an infinite loop would still occur. The user factory would need to either not automatically create a post or pass itself as the author in an `afterCreate`, like:
+The parameters passed in to `build` are automatically overlaid on top of the
+default properties defined by your factory, so it is often not necessary to
+explicitly access the params in your factory. This can, however, be useful,
+for example, if your factory uses the params to compute other properties:
 
 ```typescript
 const userFactory = Factory.define<User, Factories>(
-  ({ factories, afterCreate }) => {
-    afterCreate(user => user.posts.push(factories.post.build({ author: user })));
+  ({ params }) => {
+    const { name = 'Bob Smith' } = params;
+    const email = params.email || `${kebabCase(name)}@example.com`;
+
     return {
-      name: 'Bob',
+      name,
+      email,
       posts: [],
     };
   },
 );
 ```
-
-In normal situations, you should not have to access `params` directly. The properties passed in to `build` are automatically overlaid on top of the default properties defined by the factory.
 
 ### Params that don't map to the result object (transient params)
 
@@ -148,7 +209,7 @@ params in the second argument:
 const user = factories.user.build({}, { transient: { registered: true } });
 ```
 
-Transient params are passed in to your factory function and can then be used
+Transient params are passed in to your factory and can then be used
 however you like:
 
 ```typescript
@@ -199,22 +260,25 @@ user.permissions.canPost  // true
 
 ### After-create hook
 
-You can instruct factories to execute some code after an object is created. This can be useful if a reference to the object is needed, eg. when setting up relationships:
+You can instruct factories to execute some code after an object is created.
+This can be useful if a reference to the object is needed, like when setting
+up relationships:
 
 ```typescript
-export default Factory.define<User, Factories>(({ factories, sequence, afterCreate }) => {
-  afterCreate(user => {
-    if(user.posts.length === 0) {
-      user.posts.push(factories.post.build({ author: user })
-    }
-  });
+export default Factory.define<User, Factories>(
+  ({ factories, sequence, afterCreate }) => {
+    afterCreate(user => {
+      const post = factories.post.build({}, { associations: { author: user } });
+      user.posts.push(post);
+    });
 
-  return {
-    id: sequence,
-    name: 'Bob',
-    posts: []
-  };
-});
+    return {
+      id: sequence,
+      name: 'Bob',
+      posts: [],
+    };
+  },
+);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const user = factories.user.build({ name: 'Susan' });
 
 ### Typechecking
 
-Factories are typed, so using the factory from the above example, these would both cause TypeScript compile errors:
+Factories are typed, so the following would cause TypeScript compile errors if using the factory defined above:
 
 ```typescript
 const user = factories.user.build();
@@ -81,28 +81,41 @@ const user = factories.user.build({ foo: 'bar' }); // type error! Argument of ty
 
 ### Associations
 
-If your factory references another factory, use the `factories` object provided by the generator function:
+If your factory references another factory, use the `factories` object
+provided by the generator function:
 
 ```typescript
 const postFactory = Factory.define<Post, Factories>(
   ({ factories, params }) => ({
     title: 'My Blog Post',
-    author: params.author || factories.user.build(),
+    author: factories.user.build(),
   }),
 );
 ```
 
-There are two things to note in the example above:
-
-#### `factories` and the `Factories` type parameter
-
-In the above example, we used `factories` which is supplied by the factory generator function. Using the factories object helps avoid circular import issues where two factories need to reference each other. The `factories` object represents the combined factories object that was supplied to `register` when setting up Fishery. To get type-checking of `factories`, a second type parameter should be passed to `Factory.define`, called `Factories`. The type should be defined like:
+In the above example, the `Factories` generic parameter is passed to
+`define`. This is optional but recommended in order to get type-checking of
+the `factories` object. You can define your `Factories` object like this:
 
 ```typescript
 export interface Factories {
   user: Factory<User>;
   post: Factory<Post>;
 }
+```
+
+Once you've defined your `Factories` type, it can also be used when
+registering your factories. This ensures that your `Factories` type is always
+in sync with the actual factories that you have registered:
+
+```typescript
+// factories/index.ts
+import { register } from 'fishery';
+import user from './user';
+import post from './post';
+import { Factories } from './types';
+
+export const factories: Factories = register({ user, post });
 ```
 
 #### Use `params` to access passed in properties

--- a/lib/__tests__/associations.test.ts
+++ b/lib/__tests__/associations.test.ts
@@ -36,7 +36,9 @@ describe('associations', () => {
 
         afterCreate(user => {
           if (!skipPosts) {
-            user.posts.push(factories.post.build({}, { transient: { user } }));
+            user.posts.push(
+              factories.post.build({}, { associations: { user } }),
+            );
           }
         });
 
@@ -48,14 +50,12 @@ describe('associations', () => {
     );
 
     const postFactory = Factory.define<Post, Factories>(
-      ({ factories, transientParams, afterCreate }) => {
-        afterCreate(post => {
-          post.user.posts.push(post);
-        });
-
+      ({ factories, associations }) => {
         return {
           title: 'A Post',
-          user: transientParams.user || factories.user.build(),
+          user:
+            associations.user ||
+            factories.user.build({}, { transient: { skipPosts: true } }),
         };
       },
     );

--- a/lib/__tests__/class-factories.test.ts
+++ b/lib/__tests__/class-factories.test.ts
@@ -1,24 +1,35 @@
 import { Factory, HookFn, register } from 'fishery';
 
 describe('Using with classes', () => {
-  it('works correctly with read-only properties', () => {
-    class User {
-      constructor(readonly name: string) {}
-      greet() {
-        return `Hello, ${this.name}`;
-      }
+  class Address {
+    constructor(public city: string, public state: string) {}
+  }
+
+  class User {
+    constructor(readonly name: string, public address?: Address) {}
+    greet() {
+      return `Hello, ${this.name}`;
     }
+  }
 
-    const userFactory = Factory.define<User>(() => new User('Sharon'));
+  const userFactory = Factory.define<User>(
+    () => new User('Sharon', new Address('Detroit', 'MI')),
+  );
 
-    register({
-      user: userFactory,
-    });
+  register({
+    user: userFactory,
+  });
 
+  it('works correctly with read-only properties', () => {
     const user = userFactory.build();
     expect(user).toBeInstanceOf(User);
     expect(user.greet()).toEqual('Hello, Sharon');
     expect(userFactory.build({ name: 'Bob' }).name).toEqual('Bob');
+  });
+
+  it('accepts partials of nested class objects', () => {
+    const user = userFactory.build({ address: { city: 'Ann Arbor' } });
+    expect(user.address).toMatchObject({ city: 'Ann Arbor', state: 'MI' });
   });
 
   // TODO: show that doesn't allow private properties (feature or bug?)

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -3,6 +3,7 @@ import { register, Factory, HookFn } from 'fishery';
 type User = {
   id: string;
   name: string;
+  address?: { city: string; state: string };
 };
 
 const userFactory = Factory.define<User>(({ sequence }) => {
@@ -10,6 +11,10 @@ const userFactory = Factory.define<User>(({ sequence }) => {
   return {
     id: `user-${sequence}`,
     name,
+    address: {
+      city: 'Detroit',
+      state: 'MI',
+    },
   };
 });
 
@@ -20,6 +25,12 @@ describe('factory.build', () => {
     const user = userFactory.build({ name: 'susan' });
     expect(user.id).not.toBeNull();
     expect(user.name).toEqual('susan');
+    expect(user.address?.state).toEqual('MI');
+  });
+
+  it('accepts partials of nested objects', () => {
+    const user = userFactory.build({ address: { city: 'Ann Arbor' } });
+    expect(user.address).toMatchObject({ city: 'Ann Arbor', state: 'MI' });
   });
 });
 
@@ -38,7 +49,6 @@ describe('factory.buildList', () => {
 
     const factory = Factory.define<User>(({ afterCreate }) => {
       afterCreate(afterCreateFn);
-
       return { id: '1', name: 'Ralph' };
     });
 

--- a/lib/__tests__/sample-app/factories/post.ts
+++ b/lib/__tests__/sample-app/factories/post.ts
@@ -5,6 +5,6 @@ export default Factory.define<Post, Factories>(
   ({ sequence, params, factories }) => ({
     id: sequence,
     title: 'A Post',
-    user: params.user || factories.user.build(),
+    user: factories.user.build(params.user || {}),
   }),
 );

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,4 +1,5 @@
-import { GeneratorFn, HookFn, GeneratorFnOptions } from './types';
+import { GeneratorFn, HookFn, GeneratorFnOptions, DeepPartial } from './types';
+import merge from 'lodash.merge';
 
 export class FactoryBuilder<T, F, I> {
   private afterCreate?: HookFn<T>;
@@ -6,7 +7,7 @@ export class FactoryBuilder<T, F, I> {
     private generator: GeneratorFn<T, F, I>,
     private factories: F,
     private sequence: number,
-    private params: Partial<T>,
+    private params: DeepPartial<T>,
     private transientParams: Partial<I>,
   ) {}
 
@@ -20,7 +21,7 @@ export class FactoryBuilder<T, F, I> {
     };
 
     const object = this.generator(generatorOptions);
-    Object.assign(object, this.params);
+    merge(object, this.params);
     this._callAfterCreate(object);
     return object;
   }

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,15 +1,27 @@
-import { GeneratorFn, HookFn, GeneratorFnOptions, DeepPartial } from './types';
+import {
+  GeneratorFn,
+  HookFn,
+  GeneratorFnOptions,
+  DeepPartial,
+  BuildOptions,
+} from './types';
 import merge from 'lodash.merge';
 
 export class FactoryBuilder<T, F, I> {
   private afterCreate?: HookFn<T>;
+  private transientParams: Partial<I>;
+  private associations: Partial<T>;
+
   constructor(
     private generator: GeneratorFn<T, F, I>,
     private factories: F,
     private sequence: number,
     private params: DeepPartial<T>,
-    private transientParams: Partial<I>,
-  ) {}
+    options: BuildOptions<T, I>,
+  ) {
+    this.transientParams = options.transient || {};
+    this.associations = options.associations || {};
+  }
 
   build() {
     const generatorOptions: GeneratorFnOptions<T, F, I> = {
@@ -17,11 +29,17 @@ export class FactoryBuilder<T, F, I> {
       afterCreate: this.setAfterCreate,
       factories: this.factories,
       params: this.params,
+      associations: this.associations,
       transientParams: this.transientParams,
     };
 
     const object = this.generator(generatorOptions);
-    merge(object, this.params);
+
+    // merge params and associations into object. The only reason 'associations'
+    // is separated is because it is typed differently from `params` (Partial<T>
+    // vs DeepPartial<T>) so can do the following in a factory:
+    // `user: associations.user || factories.user.build()`
+    merge(object, this.params, this.associations);
     this._callAfterCreate(object);
     return object;
   }

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -6,8 +6,8 @@ export interface AnyFactories {
 }
 
 export class Factory<T, F = any, I = any> {
-  nextId: number = 0;
-  factories?: F;
+  private nextId: number = 0;
+  private factories?: F;
 
   constructor(private generator: GeneratorFn<T, F, I>) {}
 
@@ -45,5 +45,9 @@ export class Factory<T, F = any, I = any> {
     }
 
     return list;
+  }
+
+  setFactories(factories: F) {
+    this.factories = factories;
   }
 }

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -15,10 +15,7 @@ export class Factory<T, F = any, I = any> {
     return new Factory<T, F, I>(generator);
   }
 
-  build(
-    params: DeepPartial<T> = {},
-    options: BuildOptions<I> = { transient: {} },
-  ): T {
+  build(params: DeepPartial<T> = {}, options: BuildOptions<T, I> = {}): T {
     if (!this.factories) {
       throw new Error(
         'Factories have not been registered. Call `register` before using factories',
@@ -30,14 +27,14 @@ export class Factory<T, F = any, I = any> {
       this.factories,
       this.nextId++,
       params,
-      options.transient,
+      options,
     ).build();
   }
 
   buildList(
     number: number,
     params: DeepPartial<T> = {},
-    options: BuildOptions<I> = { transient: {} },
+    options: BuildOptions<T, I> = {},
   ): T[] {
     let list: T[] = [];
     for (let i = 0; i < number; i++) {

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -1,4 +1,4 @@
-import { GeneratorFn, BuildOptions } from './types';
+import { DeepPartial, GeneratorFn, BuildOptions } from './types';
 import { FactoryBuilder } from './builder';
 
 export interface AnyFactories {
@@ -16,7 +16,7 @@ export class Factory<T, F = any, I = any> {
   }
 
   build(
-    params: Partial<T> = {},
+    params: DeepPartial<T> = {},
     options: BuildOptions<I> = { transient: {} },
   ): T {
     if (!this.factories) {
@@ -36,7 +36,7 @@ export class Factory<T, F = any, I = any> {
 
   buildList(
     number: number,
-    params: Partial<T> = {},
+    params: DeepPartial<T> = {},
     options: BuildOptions<I> = { transient: {} },
   ): T[] {
     let list: T[] = [];

--- a/lib/register.ts
+++ b/lib/register.ts
@@ -6,7 +6,7 @@ import { AnyFactories } from './factory';
 export const register = <T extends object>(allFactories: T) => {
   const factories = allFactories as AnyFactories;
   Object.keys(factories).forEach((key: string) => {
-    factories[key].factories = factories;
+    factories[key].setFactories(factories);
   });
 
   return allFactories;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,8 @@
+export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 export type GeneratorFnOptions<T, F, I> = {
   sequence: number;
   afterCreate: (fn: HookFn<T>) => any;
-  params: Partial<T>;
+  params: DeepPartial<T>;
   transientParams: Partial<I>;
   factories: F;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,11 +3,13 @@ export type GeneratorFnOptions<T, F, I> = {
   sequence: number;
   afterCreate: (fn: HookFn<T>) => any;
   params: DeepPartial<T>;
+  associations: Partial<T>;
   transientParams: Partial<I>;
   factories: F;
 };
 export type GeneratorFn<T, F, I> = (opts: GeneratorFnOptions<T, F, I>) => T;
 export type HookFn<T> = (object: T) => any;
-export type BuildOptions<I> = {
-  transient: Partial<I>;
+export type BuildOptions<T, I> = {
+  associations?: Partial<T>;
+  transient?: Partial<I>;
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/thoughtbot/fishery#readme",
   "devDependencies": {
     "@types/jest": "^23.3.12",
+    "@types/lodash.merge": "^4.6.6",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",
     "ts-jest": "^24.1.0",
@@ -43,5 +44,8 @@
         }
       }
     ]
+  },
+  "dependencies": {
+    "lodash.merge": "^4.6.2"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/__tests__/**"]
+  "exclude": ["**/__tests__/**", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,6 +344,18 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.12.tgz#7e0ced251fa94c3bc2d1023d4b84b2992fa06376"
   integrity sha512-/kQvbVzdEpOq4tEWT79yAHSM4nH4xMlhJv2GrLVQt4Qmo8yYsPdioBM1QpN/2GX1wkfMnyXvdoftvLUr0LBj7Q==
 
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.147"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.147.tgz#8ca5cfa9c67753dcb73e507d1bbf1c4f8ba6f029"
+  integrity sha512-+0zY1Axql6ru5T85Rh6aR6Zr0xT7c0USLqsHv01b3ID//dOrV3OvpXJGjm69+4QpxoZ0oMNEfmW1ltwXe2WVzQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -2154,6 +2166,11 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
This adds support for passing in nested partials to `factory.build`. Fishery now uses a deep merge (from lodash) (instead of a shallow `Object.assign`) to merge the provided params into the resulting object. This example is now possible

```typescript
type User = {
  name: string;
  address: { city: string; state: string };
};

const userFactory = Factory.define<User>() => ({
  name,
  address: {
    city: 'Detroit',
    state: 'MI',
  },
});

// This previously threw an error: Argument of type '{ city: string; }' is not assignable to parameter of type 'Partial<User>'
const user = userFactory.build({ address: { city: 'Ann Arbor' } });
user.address.city // Ann Arbor
user.address.state // MI
```

## Todo

- [x] Fix associations tests
- [ ] Update readme if associations approach changes