### PR TITLE
Allow defining factories without calling register

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,39 @@ export default Factory.define<User, Factories>(
 );
 ```
 
+### Defining one-off factories without calling `register`
+
+Factories should usually be defined and then combined together using `register`:
+
+```typescript
+// factories/index.ts
+import { register } from 'fishery';
+import user from './user';
+import post from './post';
+import { Factories } from './types';
+
+export const factories: Factories = register({ user, post });
+```
+
+The factories passed to register get injected into each factory so factories can
+access each other. This prevents circular dependencies that could arise if your
+factories try to access other factories directly by importing them and also
+creates a convenient way for factories to access other factories without having
+to explicitly import them.
+
+If you are defining a factory for use in a single test file, you might not wish
+to register the factory or use the `factories` object that gets injected to the
+factory. In this case, you can use `defineUnregistered` instead of `define` and
+then skip calling `register`, eg:
+
+```typescript
+const personFactory = Factory.defineUnregistered<Person>(() => ({
+  name: 'Sasha',
+}));
+
+const person = personFactory.build();
+```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/__tests__/register.test.ts
+++ b/lib/__tests__/register.test.ts
@@ -1,0 +1,42 @@
+import { register, Factory, HookFn } from 'fishery';
+
+interface Post {
+  id: number;
+}
+
+describe('register', () => {
+  it('returns an object of the same type as passed in, with factories set', () => {
+    interface User {
+      post: Post;
+    }
+
+    const userFactory = Factory.define<User>(({ factories }) => ({
+      post: factories.post.build(),
+    }));
+    const postFactory = Factory.define<Post>(() => ({ id: 1 }));
+
+    const factories = register({
+      user: userFactory,
+      post: postFactory,
+    });
+
+    expect(factories.user).toEqual(userFactory);
+    expect(factories.post).toEqual(postFactory);
+    expect(factories.user.build().post.id).toBe(1);
+  });
+
+  it('raises an error if trying to build with a factory when factory not registered', () => {
+    const postFactory = Factory.define<Post>(() => ({ id: 1 }));
+    expect(() => postFactory.build()).toThrowError(
+      'Your factory has not been registered. Call `register` before using factories or define your factory with `defineUnregistered` instead of `define`',
+    );
+  });
+
+  it("can use a factory without registering if defined with 'defineUnregistered'", () => {
+    const postFactory = Factory.defineUnregistered<Post>(() => ({
+      id: 1,
+    }));
+
+    expect(postFactory.build().id).toEqual(1);
+  });
+});

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -11,14 +11,37 @@ export class Factory<T, F = any, I = any> {
 
   constructor(private generator: GeneratorFn<T, F, I>) {}
 
+  /**
+   * Define a factory. This factory needs to be registered with
+   * `register` before use.
+   * @param generator - your factory function
+   */
   static define<T, F = any, I = any>(generator: GeneratorFn<T, F, I>) {
     return new Factory<T, F, I>(generator);
   }
 
+  /**
+   * Define a factory that does not need to be registered with `register`. The
+   * factory will not have access the `factories` parameter. This can be useful
+   * for one-off factories in individual tests
+   * @param generator - your factory
+   * function
+   */
+  static defineUnregistered<T, I = any>(generator: GeneratorFn<T, null, I>) {
+    const factory = new Factory<T, null, I>(generator);
+    factory.setFactories(null);
+    return factory;
+  }
+
+  /**
+   * Build an object using your factory
+   * @param params
+   * @param options
+   */
   build(params: DeepPartial<T> = {}, options: BuildOptions<T, I> = {}): T {
-    if (!this.factories) {
+    if (typeof this.factories === 'undefined') {
       throw new Error(
-        'Factories have not been registered. Call `register` before using factories',
+        'Your factory has not been registered. Call `register` before using factories or define your factory with `defineUnregistered` instead of `define`',
       );
     }
 


### PR DESCRIPTION
This introduces `defineUnregistered`, which does not require `register` to be called on
the factory. This can be useful when defining one-off factories that are used in single tests.