### PR TITLE
Rewind a factory's sequence to its starting value

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,6 @@ You can rewind a factory's sequence at your discretion
 ```typescript
 import { factories } from './factories';
 
-factories.user.build(); // { email: 'person0@example.com' }
 factories.user.build(); // { email: 'person1@example.com' }
 factories.user.build(); // { email: 'person2@example.com' }
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,33 @@ const personFactory = Factory.defineUnregistered<Person>(() => ({
 const person = personFactory.build();
 ```
 
+### Rewind Sequence
+
+A factory's sequence can be rewound with `rewindSequence()`.
+This sets the sequence back to its original starting value.
+
+Given the following factory
+
+```typescript
+export default Factory.define<User>(({ sequence }) => ({
+  email: `person${sequence}@example.com`,
+}));
+```
+
+You can rewind a factory's sequence at your discretion
+
+```typescript
+import { factories } from './factories';
+
+factories.user.build(); // { email: 'person0@example.com' }
+factories.user.build(); // { email: 'person1@example.com' }
+factories.user.build(); // { email: 'person2@example.com' }
+
+factories.user.rewindSequence();
+
+factories.user.build(); // { email: 'person0@example.com' }
+```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ factories.user.build(); // { email: 'person2@example.com' }
 
 factories.user.rewindSequence();
 
-factories.user.build(); // { email: 'person0@example.com' }
+factories.user.build(); // { email: 'person1@example.com' }
 ```
 
 ## Contributing

--- a/lib/__tests__/factory-sample-app.test.ts
+++ b/lib/__tests__/factory-sample-app.test.ts
@@ -7,21 +7,3 @@ describe('Factory.build', () => {
     expect(user.name).toEqual('susan');
   });
 });
-
-describe('Factory.rewindSequence', () => {
-  beforeEach(() => {
-    factories.user.rewindSequence();
-  });
-
-  it('creates the object', () => {
-    const user = factories.user.build({ name: 'susan' });
-    expect(user.id).toBe('user-0');
-    expect(user.name).toBe('susan');
-  });
-
-  it('sets sequence back to zero after beforeEach hook', () => {
-    const user = factories.user.build({ name: 'susan' });
-    expect(user.id).toBe('user-0');
-    expect(user.name).toBe('susan');
-  });
-});

--- a/lib/__tests__/factory-sample-app.test.ts
+++ b/lib/__tests__/factory-sample-app.test.ts
@@ -7,3 +7,21 @@ describe('Factory.build', () => {
     expect(user.name).toEqual('susan');
   });
 });
+
+describe('Factory.rewindSequence', () => {
+  beforeEach(() => {
+    factories.user.rewindSequence();
+  });
+
+  it('creates the object', () => {
+    const user = factories.user.build({ name: 'susan' });
+    expect(user.id).toBe('user-0');
+    expect(user.name).toBe('susan');
+  });
+
+  it('sets sequence back to zero after beforeEach hook', () => {
+    const user = factories.user.build({ name: 'susan' });
+    expect(user.id).toBe('user-0');
+    expect(user.name).toBe('susan');
+  });
+});

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -102,7 +102,7 @@ describe('factory.rewindSequence', () => {
     expect(factory.build().id).toBe('user-2');
   });
 
-  it('sets sequence back to zero after buildList', () => {
+  it('sets sequence back to one after buildList', () => {
     const factory = Factory.define<User>(({ sequence }) => {
       return { id: `user-${sequence}`, name: 'Ralph' };
     });

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -95,11 +95,11 @@ describe('factory.rewindSequence', () => {
 
     register({ user: factory });
 
-    expect(factory.build().id).toBe('user-0');
+    expect(factory.build().id).toBe('user-1');
 
     factory.rewindSequence();
-    expect(factory.build().id).toBe('user-0');
     expect(factory.build().id).toBe('user-1');
+    expect(factory.build().id).toBe('user-2');
   });
 
   it('sets sequence back to zero after buildList', () => {
@@ -110,15 +110,15 @@ describe('factory.rewindSequence', () => {
     register({ user: factory });
 
     expect(factory.buildList(2)).toEqual([
-      { id: 'user-0', name: 'Ralph' },
       { id: 'user-1', name: 'Ralph' },
+      { id: 'user-2', name: 'Ralph' },
     ]);
 
     factory.rewindSequence();
 
     expect(factory.buildList(2)).toEqual([
-      { id: 'user-0', name: 'Ralph' },
       { id: 'user-1', name: 'Ralph' },
+      { id: 'user-2', name: 'Ralph' },
     ]);
   });
 });

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -86,3 +86,39 @@ describe('afterCreate', () => {
     });
   });
 });
+
+describe('factory.rewindSequence', () => {
+  it('sets sequence back to zero after build', () => {
+    const factory = Factory.define<User>(({ sequence }) => {
+      return { id: `user-${sequence}`, name: 'Ralph' };
+    });
+
+    register({ user: factory });
+
+    expect(factory.build().id).toBe('user-0');
+
+    factory.rewindSequence();
+    expect(factory.build().id).toBe('user-0');
+    expect(factory.build().id).toBe('user-1');
+  });
+
+  it('sets sequence back to zero after buildList', () => {
+    const factory = Factory.define<User>(({ sequence }) => {
+      return { id: `user-${sequence}`, name: 'Ralph' };
+    });
+
+    register({ user: factory });
+
+    expect(factory.buildList(2)).toEqual([
+      { id: 'user-0', name: 'Ralph' },
+      { id: 'user-1', name: 'Ralph' },
+    ]);
+
+    factory.rewindSequence();
+
+    expect(factory.buildList(2)).toEqual([
+      { id: 'user-0', name: 'Ralph' },
+      { id: 'user-1', name: 'Ralph' },
+    ]);
+  });
+});

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -88,7 +88,7 @@ describe('afterCreate', () => {
 });
 
 describe('factory.rewindSequence', () => {
-  it('sets sequence back to zero after build', () => {
+  it('sets sequence back to one after build', () => {
     const factory = Factory.define<User>(({ sequence }) => {
       return { id: `user-${sequence}`, name: 'Ralph' };
     });

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -11,7 +11,7 @@ export interface AnyFactories {
   [key: string]: Factory<any>;
 }
 
-const SEQUENCE_START_VALUE: number = 1;
+const SEQUENCE_START_VALUE = 1;
 
 export class Factory<T, F = any, I = any> {
   private nextId: number = SEQUENCE_START_VALUE;

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -11,8 +11,10 @@ export interface AnyFactories {
   [key: string]: Factory<any>;
 }
 
+const SEQUENCE_START_VALUE: number = 0;
+
 export class Factory<T, F = any, I = any> {
-  private nextId: number = 0;
+  private nextId: number = SEQUENCE_START_VALUE;
   private factories?: F;
   private _afterCreates: HookFn<T>[] = [];
   private _associations: Partial<T> = {};
@@ -129,6 +131,13 @@ export class Factory<T, F = any, I = any> {
     const factory = this.clone();
     factory._transient = { ...this._transient, ...transient };
     return factory;
+  }
+
+  /**
+   * Sets sequence back to its default value
+   */
+  rewindSequence() {
+    this.nextId = SEQUENCE_START_VALUE;
   }
 
   setFactories(factories: F) {

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -11,7 +11,7 @@ export interface AnyFactories {
   [key: string]: Factory<any>;
 }
 
-const SEQUENCE_START_VALUE: number = 0;
+const SEQUENCE_START_VALUE: number = 1;
 
 export class Factory<T, F = any, I = any> {
   private nextId: number = SEQUENCE_START_VALUE;


### PR DESCRIPTION
## WHAT are you doing in this PR?
Adding a method to reset a factory's sequence back to the original value


## WHY are you doing this?
I encountered a scenario where I needed values derived from/with the `sequence` value to be consistent across tests. After a bit of research, I came across the concept of [rewinding a sequence](https://github.com/thoughtbot/factory_bot/commit/50eeb67241ea78a6b138eea694a2a25413052f49) in `factory_bot`, which is where the inspiration for this PR comes from. 


## How are you doing this?
Introducing a method to the `Factory` class called `rewindSequence`. This method sets the value of `nextId` back to the starting value. Since a `sequence` in `fishery` is just a number that increases by `+1`, this seems like the optimal approach.
