### PR TITLE
Rename 'afterCreate' hook to 'afterBuild'

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ const user = factories.user.build({ foo: 'bar' }); // type error! Argument of ty
 
 ```typescript
 export default Factory.define<User, Factories, UserTransientParams>(
-  ({ sequence, params, transientParams, associations, afterCreate }) => {
+  ({ sequence, params, transientParams, associations, afterBuild }) => {
     params.firstName; // Property 'firstName' does not exist on type 'DeepPartial<User>
     transientParams.foo; // Property 'foo' does not exist on type 'Partial<UserTransientParams>'
     associations.bar; // Property 'bar' does not exist on type 'Partial<User>'
 
-    afterCreate(user => {
+    afterBuild(user => {
       user.foo; // Property 'foo' does not exist on type 'User'
     });
 
@@ -279,8 +279,8 @@ up relationships:
 
 ```typescript
 export default Factory.define<User, Factories>(
-  ({ factories, sequence, afterCreate }) => {
-    afterCreate(user => {
+  ({ factories, sequence, afterBuild }) => {
+    afterBuild(user => {
       const post = factories.post.build({}, { associations: { author: user } });
       user.posts.push(post);
     });
@@ -297,7 +297,7 @@ export default Factory.define<User, Factories>(
 ### Extending factories
 
 Factories can easily be extended using the extension methods: `params`,
-`transient`, `associations`, and `afterCreate`. These set default attributes that get passed to the factory on `build`:
+`transient`, `associations`, and `afterBuild`. These set default attributes that get passed to the factory on `build`:
 
 ```typescript
 const userFactory = Factory.define<User>(() => ({
@@ -311,14 +311,14 @@ admin.admin; // true
 ```
 
 Factories are immutable, so the extension methods return a new factory with
-the specified `params`, `transientParams`, `associations`, or `afterCreate`
+the specified `params`, `transientParams`, `associations`, or `afterBuild`
 added to it. When `build` is called on the factory, the `params`,
 `transientParams`, and `associations` are passed in along with the values
 supplied to `build`. Values supplied to `build` override these defaults.
 
-`afterCreate` just adds a function that is called when the object is built.
-The `afterCreate` defined in `Factory.define` is always called first if
-specified, and then any `afterCreate` functions defined with the extension
+`afterBuild` just adds a function that is called when the object is built.
+The `afterBuild` defined in `Factory.define` is always called first if
+specified, and then any `afterBuild` functions defined with the extension
 method are called sequentially in the order they were added.
 
 These extension methods can be called multiple times to continue extending
@@ -328,8 +328,8 @@ factories, and they do not modify the original factory:
 const eliFactory = userFactory
   .params({ admin: true })
   .params({ name: 'Eli' })
-  .afterCreate(user => console.log('hello'))
-  .afterCreate(user => console.log('there'));
+  .afterBuild(user => console.log('hello'))
+  .afterBuild(user => console.log('there'));
 
 const user = eliFactory.build();
 // log: hello
@@ -365,7 +365,7 @@ class UserFactory extends Factory<User, Factories, UserTransientParams> {
       .params({ memberId: this.sequence() })
       .transient({ registered: true })
       .associations({ profile: factories.profile.build() })
-      .afterCreate(user => console.log(user))
+      .afterBuild(user => console.log(user))
   }
 }
 
@@ -376,7 +376,7 @@ const user = userFactory.admin().registered().build()
 ```
 
 To learn more about the factory builder methods `params`, `transient`,
-`associations`, and `afterCreate`, see [Extending factories](#extending-factories), above.
+`associations`, and `afterBuild`, see [Extending factories](#extending-factories), above.
 
 ### Defining one-off factories without calling `register`
 

--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ Passing transient params to `build` can be a bit verbose. It is often a good
 idea to consider creating a [reusable builder method](#adding-reusable-builders-traits-to-factories) instead of or in
 addition to your transient params to make building objects simpler.
 
-### After-create hook
+### After-build hook
 
-You can instruct factories to execute some code after an object is created.
+You can instruct factories to execute some code after an object is built.
 This can be useful if a reference to the object is needed, like when setting
 up relationships:
 

--- a/lib/__tests__/associations.test.ts
+++ b/lib/__tests__/associations.test.ts
@@ -31,10 +31,10 @@ describe('associations', () => {
 
   it('can create bi-directional has-many/belongs-to associations', () => {
     const userFactory = Factory.define<User, Factories>(
-      ({ factories, afterCreate, transientParams }) => {
+      ({ factories, afterBuild, transientParams }) => {
         const { skipPosts } = transientParams;
 
-        afterCreate(user => {
+        afterBuild(user => {
           if (!skipPosts) {
             user.posts.push(
               factories.post.build({}, { associations: { user } }),

--- a/lib/__tests__/factory-builders.test.ts
+++ b/lib/__tests__/factory-builders.test.ts
@@ -46,56 +46,56 @@ const userFactory = UserFactory.define(({ associations, transientParams }) => {
 
 register({ user: userFactory, post: postFactory });
 
-describe('afterCreate', () => {
+describe('afterBuild', () => {
   it('defines a function that is called after build', () => {
-    const afterCreate = jest.fn(user => {
+    const afterBuild = jest.fn(user => {
       user.id = '123';
       return user;
     });
-    const user = userFactory.afterCreate(afterCreate).build();
+    const user = userFactory.afterBuild(afterBuild).build();
     expect(user.id).toEqual('123');
-    expect(afterCreate).toHaveBeenCalledWith(user);
+    expect(afterBuild).toHaveBeenCalledWith(user);
   });
 
-  it('calls chained or inherited afterCreates sequentially', () => {
-    const afterCreate1 = jest.fn(user => {
+  it('calls chained or inherited afterBuilds sequentially', () => {
+    const afterBuild1 = jest.fn(user => {
       user.id = 'a';
       return user;
     });
-    const afterCreate2 = jest.fn(user => {
+    const afterBuild2 = jest.fn(user => {
       user.id = 'b';
       return user;
     });
 
     const user = userFactory
-      .afterCreate(afterCreate1)
-      .afterCreate(afterCreate2)
+      .afterBuild(afterBuild1)
+      .afterBuild(afterBuild2)
       .build();
     expect(user.id).toEqual('b');
-    expect(afterCreate1).toHaveBeenCalledTimes(1);
-    expect(afterCreate2).toHaveBeenCalledTimes(1);
+    expect(afterBuild1).toHaveBeenCalledTimes(1);
+    expect(afterBuild2).toHaveBeenCalledTimes(1);
   });
 
-  it('calls afterCreate from the generator function before those later defined by builder', () => {
-    const afterCreateGenerator = jest.fn(user => {
+  it('calls afterBuild from the generator function before those later defined by builder', () => {
+    const afterBuildGenerator = jest.fn(user => {
       user.id = 'generator';
       return user;
     });
-    const afterCreateBuilder = jest.fn(user => {
+    const afterBuildBuilder = jest.fn(user => {
       user.id = 'builder';
       return user;
     });
 
     type User = { id: string };
-    const userFactory = Factory.defineUnregistered<User>(({ afterCreate }) => {
-      afterCreate(afterCreateGenerator);
+    const userFactory = Factory.defineUnregistered<User>(({ afterBuild }) => {
+      afterBuild(afterBuildGenerator);
       return { id: '1' };
     });
 
-    const user = userFactory.afterCreate(afterCreateBuilder).build();
+    const user = userFactory.afterBuild(afterBuildBuilder).build();
     expect(user.id).toEqual('builder');
-    expect(afterCreateGenerator).toHaveBeenCalledTimes(1);
-    expect(afterCreateBuilder).toHaveBeenCalledTimes(1);
+    expect(afterBuildGenerator).toHaveBeenCalledTimes(1);
+    expect(afterBuildBuilder).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/lib/__tests__/factory-sample-app.test.ts
+++ b/lib/__tests__/factory-sample-app.test.ts
@@ -1,7 +1,7 @@
 import { factories } from './sample-app/factories';
 
 describe('Factory.build', () => {
-  it('creates the object', () => {
+  it('builds the object', () => {
     const user = factories.user.build({ name: 'susan' });
     expect(user.id).not.toBeNull();
     expect(user.name).toEqual('susan');

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -21,7 +21,7 @@ const userFactory = Factory.define<User>(({ sequence }) => {
 register({ user: userFactory });
 
 describe('factory.build', () => {
-  it('creates the object', () => {
+  it('builds the object', () => {
     const user = userFactory.build({ name: 'susan' });
     expect(user.id).not.toBeNull();
     expect(user.name).toEqual('susan');
@@ -35,7 +35,7 @@ describe('factory.build', () => {
 });
 
 describe('factory.buildList', () => {
-  it('creates a list of objects with the specified properties', () => {
+  it('builds a list of objects with the specified properties', () => {
     const users = userFactory.buildList(2, { name: 'susan' });
     expect(users.length).toBe(2);
     expect(users[0].id).not.toEqual(users[1].id);

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -42,26 +42,26 @@ describe('factory.buildList', () => {
     expect(users.map(u => u.name)).toEqual(['susan', 'susan']);
   });
 
-  it('calls afterCreate for each item', () => {
-    const afterCreateFn = jest.fn(user => {
+  it('calls afterBuild for each item', () => {
+    const afterBuildFn = jest.fn(user => {
       user.name = 'Bill';
     });
 
-    const factory = Factory.define<User>(({ afterCreate }) => {
-      afterCreate(afterCreateFn);
+    const factory = Factory.define<User>(({ afterBuild }) => {
+      afterBuild(afterBuildFn);
       return { id: '1', name: 'Ralph' };
     });
 
     register({ user: factory });
     expect(factory.buildList(2).every(u => u.name === 'Bill')).toBeTruthy();
-    expect(afterCreateFn).toHaveBeenCalledTimes(2);
+    expect(afterBuildFn).toHaveBeenCalledTimes(2);
   });
 });
 
-describe('afterCreate', () => {
+describe('afterBuild', () => {
   it('passes the object for manipulation', () => {
-    const factory = Factory.define<User>(({ afterCreate }) => {
-      afterCreate(user => {
+    const factory = Factory.define<User>(({ afterBuild }) => {
+      afterBuild(user => {
         user.id = 'bla';
       });
 
@@ -74,8 +74,8 @@ describe('afterCreate', () => {
 
   describe('when not a function', () => {
     it('raises an error', () => {
-      const factory = Factory.define<User>(({ afterCreate }) => {
-        afterCreate(('5' as unknown) as HookFn<User>);
+      const factory = Factory.define<User>(({ afterBuild }) => {
+        afterBuild(('5' as unknown) as HookFn<User>);
         return { id: '1', name: 'Ralph' };
       });
 

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -9,13 +9,13 @@ export class FactoryBuilder<T, F, I> {
     private params: DeepPartial<T>,
     private transientParams: Partial<I>,
     private associations: Partial<T>,
-    private afterCreates: HookFn<T>[],
+    private afterBuilds: HookFn<T>[],
   ) {}
 
   build() {
     const generatorOptions: GeneratorFnOptions<T, F, I> = {
       sequence: this.sequence,
-      afterCreate: this.setAfterCreate,
+      afterBuild: this.setAfterCreate,
       factories: this.factories,
       params: this.params,
       associations: this.associations,
@@ -34,15 +34,15 @@ export class FactoryBuilder<T, F, I> {
   }
 
   setAfterCreate = (hook: HookFn<T>) => {
-    this.afterCreates = [hook, ...this.afterCreates];
+    this.afterBuilds = [hook, ...this.afterBuilds];
   };
 
   _callAfterCreates(object: T) {
-    this.afterCreates.forEach(afterCreate => {
-      if (typeof afterCreate === 'function') {
-        afterCreate(object);
+    this.afterBuilds.forEach(afterBuild => {
+      if (typeof afterBuild === 'function') {
+        afterBuild(object);
       } else {
-        throw new Error('"afterCreate" must be a function');
+        throw new Error('"afterBuild" must be a function');
       }
     });
   }

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -15,7 +15,7 @@ export class FactoryBuilder<T, F, I> {
   build() {
     const generatorOptions: GeneratorFnOptions<T, F, I> = {
       sequence: this.sequence,
-      afterBuild: this.setAfterCreate,
+      afterBuild: this.setAfterBuild,
       factories: this.factories,
       params: this.params,
       associations: this.associations,
@@ -29,15 +29,15 @@ export class FactoryBuilder<T, F, I> {
     // vs DeepPartial<T>) so can do the following in a factory:
     // `user: associations.user || factories.user.build()`
     merge(object, this.params, this.associations);
-    this._callAfterCreates(object);
+    this._callAfterBuilds(object);
     return object;
   }
 
-  setAfterCreate = (hook: HookFn<T>) => {
+  setAfterBuild = (hook: HookFn<T>) => {
     this.afterBuilds = [hook, ...this.afterBuilds];
   };
 
-  _callAfterCreates(object: T) {
+  _callAfterBuilds(object: T) {
     this.afterBuilds.forEach(afterBuild => {
       if (typeof afterBuild === 'function') {
         afterBuild(object);

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -14,7 +14,7 @@ export interface AnyFactories {
 export class Factory<T, F = any, I = any> {
   private nextId: number = 0;
   private factories?: F;
-  private _afterCreates: HookFn<T>[] = [];
+  private _afterBuilds: HookFn<T>[] = [];
   private _associations: Partial<T> = {};
   private _params: DeepPartial<T> = {};
   private _transient: Partial<I> = {};
@@ -70,7 +70,7 @@ export class Factory<T, F = any, I = any> {
       { ...this._params, ...params },
       { ...this._transient, ...options.transient },
       { ...this._associations, ...options.associations },
-      this._afterCreates,
+      this._afterBuilds,
     ).build();
   }
 
@@ -89,12 +89,12 @@ export class Factory<T, F = any, I = any> {
 
   /**
    * Extend the factory by adding a function to be called after an object is built.
-   * @param afterCreateFn - the function to call. It accepts your object of type T. The value this function returns gets returned from "build"
+   * @param afterBuildFn - the function to call. It accepts your object of type T. The value this function returns gets returned from "build"
    * @returns a new factory
    */
-  afterCreate(afterCreateFn: HookFn<T>): this {
+  afterBuild(afterBuildFn: HookFn<T>): this {
     const factory = this.clone();
-    factory._afterCreates.push(afterCreateFn);
+    factory._afterBuilds.push(afterBuildFn);
     return factory;
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 export type GeneratorFnOptions<T, F, I> = {
   sequence: number;
-  afterCreate: (fn: HookFn<T>) => any;
+  afterBuild: (fn: HookFn<T>) => any;
   params: DeepPartial<T>;
   associations: Partial<T>;
   transientParams: Partial<I>;


### PR DESCRIPTION
Since [async factories](https://github.com/thoughtbot/fishery/issues/16) will likely be coming to Fishery soon, along with a `factory.create()` API, the existing `afterCreate` hook that runs when an object is built would cause confusion.

This renames `afterCreate` to `afterBuild` to prevent that confusion and to pave the way for an `afterCreate` once async factories are introduced.

What this does:

* The first two commits are literal "find and replace" operations in the codebase
* The last commit changes a couple other uses of "create" to be "build" to make sure our terminology is correct

This is a breaking change and will be included in a major version release, likely along with #21.