### PR TITLE
Revert "Modify DeepPartial to recurse for objects only (#30)"

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,4 @@
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
-};
+export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;


### PR DESCRIPTION
This reverts #30, which was causing tests to fail. We can open a new PR once a fix is discovered.