### PR TITLE
Modify DeepPartial to work with 'unknown' type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
+export type DeepPartial<T> = { [P in keyof T]?: unknown extends T[P] ? T[P] : DeepPartial<T[P]> };
 export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "test": "jest",
     "testinit": "jest --init",
+    "prepare": "npm run build",
     "pretty": "prettier --write '{*,.*,lib/**/*}.{ts,json,md}'",
     "verifyPretty": "prettier --check '{*,.*,lib/**/*}.{ts,json,md}'"
   },


### PR DESCRIPTION
Fixes #29 

My first attempt to fix this issue (in #30) [caused unanticipated TypeScript errors](https://github.com/thoughtbot/fishery/pull/30#issuecomment-652498038). See [my follow-up comments](https://github.com/thoughtbot/fishery/pull/30#issuecomment-654419567) for more information. The solution in this PR is more narrow and does not appear to cause any errors.

@OliverJAsh, I'm mentioning you in case this update interests you.