### PR TITLE
Update deep merge behavior to ignore arrays

### DIFF
--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -114,48 +114,132 @@ describe('factory.rewindSequence', () => {
   });
 });
 
-describe('factory.tuples', () => {
-  it('builds a tuple', () => {
-    expect(
-      Factory.define<[string]>(() => ['STRING']).build(),
-    ).toEqual(['STRING']);
+describe('merging params', () => {
+  describe('factory.tuples', () => {
+    const tupleFactory = Factory.define<{ items: [string] }>(() => ({
+      items: ['STRING'],
+    }));
+
+    it('builds a tuple with default value', () => {
+      expect(tupleFactory.build().items).toEqual(['STRING']);
+    });
+
+    it('generates a compile error when tuple not defined', () => {
+      // @ts-expect-error
+      tupleFactory.build({ items: [] });
+    });
+
+    it('overrides the tuple when passed to build', () => {
+      expect(
+        Factory.define<[string]>(() => ['STRING']).build(['VALUE']),
+      ).toEqual(['VALUE']);
+    });
   });
 
-  it('not overrides the tuple with empty array', () => {
-    expect(
-      Factory.define<[string]>(() => ['STRING']).build([]),
-    ).toEqual(['STRING']);
+  describe('factory.arrays', () => {
+    const arrayFactory = Factory.define<{ items: string[] }>(() => ({
+      items: ['STRING'],
+    }));
+
+    it('builds an empty array of strings', () => {
+      expect(arrayFactory.build({ items: [] }).items).toEqual([]);
+    });
+
+    it('builds a non-empty array of string', () => {
+      expect(arrayFactory.build().items).toEqual(['STRING']);
+    });
+
+    it('overrides the array', () => {
+      expect(arrayFactory.build({ items: ['VALUE'] }).items).toEqual(['VALUE']);
+    });
+
+    it('doesnt allow passing a partial of an array object', () => {
+      type User = {
+        id: string;
+        name: string;
+      };
+
+      const arrayFactory = Factory.define<{ users: User[] }>(() => ({
+        users: [{ id: '1', name: 'Oscar' }],
+      }));
+
+      // @ts-expect-error
+      arrayFactory.build({ users: [{ id: '2' }] });
+    });
+
+    it('correctly types "params" in the factory to the full array with no compiler error', () => {
+      Factory.define<{ items: string[] }>(({ params }) => ({
+        items: params.items || ['hello'],
+      }));
+    });
   });
 
-  it('overrides the tuple', () => {
-    expect(
-      Factory.define<[string]>(() => ['STRING']).build(['VALUE']),
-    ).toEqual(['VALUE']);
-  });
-});
+  describe('factories.unknown', () => {
+    it('does not generate compiler error for unknown', () => {
+      interface User {
+        something: unknown;
+        somethingOptional?: unknown;
+      }
 
-describe('factory.arrays', () => {
-  it('builds an empty array of strings', () => {
-    expect(
-      Factory.define<string[]>(() => []).build(),
-    ).toEqual([]);
-  });
+      const userFactory = Factory.define<User>(() => ({
+        something: 'blah',
+      }));
 
-  it('builds a non-empty array of string', () => {
-    expect(
-      Factory.define<string[]>(() => ['STRING']).build(),
-    ).toEqual(['STRING']);
-  });
+      userFactory.build({ something: 1, somethingOptional: 'sdf' });
+      userFactory.build();
+    });
 
-  it('overrides the array', () => {
-    expect(
-      Factory.define<string[]>(() => ['STRING']).build(['VALUE']),
-    ).toEqual(['VALUE']);
-  });
+    it('does not generate compiler error with unknown inside of arrays', () => {
+      interface Entity1 {
+        entity2: Entity2;
+      }
 
-  it('overrides the array with empty array', () => {
-    expect(
-      Factory.define<string[]>(() => ['STRING']).build([]),
-    ).toEqual([]);
+      interface Entity2 {
+        id: string;
+        entity3: Array<Entity3>;
+        entity3Optional?: Array<Entity3>;
+      }
+
+      interface Entity3 {
+        _permissions: unknown;
+      }
+
+      const entity2Factory = Factory.define<Entity2>(() => ({
+        id: 'abc',
+        entity3: [],
+        entity3Optional: [],
+      }));
+
+      const entity2 = entity2Factory.build();
+
+      const entity1Factory = Factory.define<Entity1>(() => ({
+        entity2: entity2Factory.build(),
+      }));
+
+      entity1Factory.build({ entity2: entity2 });
+    });
+
+    it('does not generate compiler error with unknown nested in object', () => {
+      interface Entity1 {
+        entity2: Entity2;
+      }
+
+      interface Entity2 {
+        entity3: { _permissions: unknown };
+      }
+
+      const entity2Factory = Factory.define<Entity2>(() => ({
+        id: 'abc',
+        entity3: { _permissions: 'foo' },
+      }));
+
+      const entity2 = entity2Factory.build();
+
+      const entity1Factory = Factory.define<Entity1>(() => ({
+        entity2: entity2Factory.build(),
+      }));
+
+      entity1Factory.build({ entity2 });
+    });
   });
 });

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -113,3 +113,49 @@ describe('factory.rewindSequence', () => {
     ]);
   });
 });
+
+describe('factory.tuples', () => {
+  it('builds a tuple', () => {
+    expect(
+      Factory.define<[string]>(() => ['STRING']).build(),
+    ).toEqual(['STRING']);
+  });
+
+  it('not overrides the tuple with empty array', () => {
+    expect(
+      Factory.define<[string]>(() => ['STRING']).build([]),
+    ).toEqual(['STRING']);
+  });
+
+  it('overrides the tuple', () => {
+    expect(
+      Factory.define<[string]>(() => ['STRING']).build(['VALUE']),
+    ).toEqual(['VALUE']);
+  });
+});
+
+describe('factory.arrays', () => {
+  it('builds an empty array of strings', () => {
+    expect(
+      Factory.define<string[]>(() => []).build(),
+    ).toEqual([]);
+  });
+
+  it('builds a non-empty array of string', () => {
+    expect(
+      Factory.define<string[]>(() => ['STRING']).build(),
+    ).toEqual(['STRING']);
+  });
+
+  it('overrides the array', () => {
+    expect(
+      Factory.define<string[]>(() => ['STRING']).build(['VALUE']),
+    ).toEqual(['VALUE']);
+  });
+
+  it('overrides the array with empty array', () => {
+    expect(
+      Factory.define<string[]>(() => ['STRING']).build([]),
+    ).toEqual([]);
+  });
+});

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,5 +1,6 @@
 import { GeneratorFn, HookFn, GeneratorFnOptions, DeepPartial } from './types';
-import merge from 'lodash.merge';
+import isArray from 'lodash.isarray';
+import mergeWith from 'lodash.mergewith';
 
 export class FactoryBuilder<T, I> {
   constructor(
@@ -21,12 +22,7 @@ export class FactoryBuilder<T, I> {
     };
 
     const object = this.generator(generatorOptions);
-
-    // merge params and associations into object. The only reason 'associations'
-    // is separated is because it is typed differently from `params` (Partial<T>
-    // vs DeepPartial<T>) so can do the following in a factory:
-    // `user: associations.user || userFactory.build()`
-    merge(object, this.params, this.associations);
+    this._mergeParamsOntoObject(object);
     this._callAfterBuilds(object);
     return object;
   }
@@ -34,6 +30,14 @@ export class FactoryBuilder<T, I> {
   setAfterBuild = (hook: HookFn<T>) => {
     this.afterBuilds = [hook, ...this.afterBuilds];
   };
+
+  // merge params and associations into object. The only reason 'associations'
+  // is separated is because it is typed differently from `params` (Partial<T>
+  // vs DeepPartial<T>) so can do the following in a factory:
+  // `user: associations.user || userFactory.build()`
+  _mergeParamsOntoObject(object: T) {
+    mergeWith(object, this.params, this.associations, mergeCustomizer);
+  }
 
   _callAfterBuilds(object: T) {
     this.afterBuilds.forEach(afterBuild => {
@@ -45,3 +49,9 @@ export class FactoryBuilder<T, I> {
     });
   }
 }
+
+const mergeCustomizer = (_object: any, srcVal: any) => {
+  if (isArray(srcVal)) {
+    return srcVal;
+  }
+};

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,5 +1,4 @@
 import { GeneratorFn, HookFn, GeneratorFnOptions, DeepPartial } from './types';
-import isArray from 'lodash.isarray';
 import mergeWith from 'lodash.mergewith';
 
 export class FactoryBuilder<T, I> {
@@ -51,7 +50,7 @@ export class FactoryBuilder<T, I> {
 }
 
 const mergeCustomizer = (_object: any, srcVal: any) => {
-  if (isArray(srcVal)) {
+  if (Array.isArray(srcVal)) {
     return srcVal;
   }
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,11 @@
 export type DeepPartial<T> = {
-  [P in keyof T]?: unknown extends T[P] ? T[P] : DeepPartial<T[P]>;
+  [P in keyof T]?: unknown extends T[P]
+    ? T[P]
+    : T[P] extends Array<any>
+    ? T[P]
+    : DeepPartial<T[P]>;
 };
+
 export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;

--- a/package.json
+++ b/package.json
@@ -51,13 +51,15 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.3",
-    "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.isarray": "^4.0.6",
+    "@types/lodash.mergewith": "^4.6.6",
     "jest": "^26.1.0",
     "prettier": "^2.0.5",
     "ts-jest": "^26.1.1",
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "lodash.merge": "^4.6.2"
+    "lodash.isarray": "^4.0.0",
+    "lodash.mergewith": "^4.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.3",
-    "@types/lodash.isarray": "^4.0.6",
     "@types/lodash.mergewith": "^4.6.6",
     "jest": "^26.1.0",
     "prettier": "^2.0.5",
@@ -59,7 +58,6 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "lodash.isarray": "^4.0.0",
     "lodash.mergewith": "^4.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,13 +551,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/lodash.isarray@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isarray/-/lodash.isarray-4.0.6.tgz#5979c4301508d9571dfb740b81a2f172b7382ade"
-  integrity sha512-lXLDKJ4jWhtAd6EVQOGHwX8iKJlITY5J+HAgim6oglepJrPXAv7hdoN7hrJSwpOYZ7oEpMng+bPasl4LZWp4GQ==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash.mergewith@^4.6.6":
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
@@ -2369,11 +2362,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-lodash.isarray@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
-  integrity sha1-KspJayjEym1yZxUxNZDALm6jRAM=
 
 lodash.memoize@4.x:
   version "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,10 +551,17 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/lodash.merge@^4.6.6":
+"@types/lodash.isarray@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isarray/-/lodash.isarray-4.0.6.tgz#5979c4301508d9571dfb740b81a2f172b7382ade"
+  integrity sha512-lXLDKJ4jWhtAd6EVQOGHwX8iKJlITY5J+HAgim6oglepJrPXAv7hdoN7hrJSwpOYZ7oEpMng+bPasl4LZWp4GQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.mergewith@^4.6.6":
   version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
-  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
+  integrity sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==
   dependencies:
     "@types/lodash" "*"
 
@@ -2363,15 +2370,20 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.isarray@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
+  integrity sha1-KspJayjEym1yZxUxNZDALm6jRAM=
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.6.2:
+lodash.mergewith@^4.6.2:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
As reported in #36, building a factory with an empty array was not overriding a non-empty array if it was defined that way in a factory: 

```typescript
const elementsFactory = Factory.define<Elements>(() => ({
  elements: ["STRING"],
}));

elementsFactory.build({ elements: [] }));
// { elements: ["STRING"] }
```

This was due to [surprising behavior of `lodash.merge`](https://github.com/lodash/lodash/issues/1313).

* Switches to `lodash.mergeWith` with `customizer` function so arrays passed to `build` as `params` or `associations` completely replace those defined in the factory
* Updates `DeepPartial` definition to take into account that arrays are not deep merged
* Adds tests around arrays and tuples, thanks to @shagabutdinov in #37.
* Adds tests around the `DeepPartial` typing

Big thanks to @shagabutdinov for bringing this issues to my attention and for your help in writing the tests.

Closes #36, #37. 