### PR TITLE
Support for async creation

### DIFF
--- a/lib/__tests__/factory-sample-app.test.ts
+++ b/lib/__tests__/factory-sample-app.test.ts
@@ -12,7 +12,7 @@ describe('Factory.build', () => {
 describe('Factory.create', () => {
   it('creates the object', async () => {
     const promise = factories.user.create({ name: 'susan' });
-    expect( promise ).toBeInstanceOf( Promise );
+    expect(promise).toBeInstanceOf(Promise);
 
     const user = await promise;
     expect(user.id).not.toBeNull();

--- a/lib/__tests__/factory-sample-app.test.ts
+++ b/lib/__tests__/factory-sample-app.test.ts
@@ -4,6 +4,19 @@ describe('Factory.build', () => {
   it('builds the object', () => {
     const user = factories.user.build({ name: 'susan' });
     expect(user.id).not.toBeNull();
+    expect(user.created).not.toBe(true);
+    expect(user.name).toEqual('susan');
+  });
+});
+
+describe('Factory.create', () => {
+  it('creates the object', async () => {
+    const promise = factories.user.create({ name: 'susan' });
+    expect( promise ).toBeInstanceOf( Promise );
+
+    const user = await promise;
+    expect(user.id).not.toBeNull();
+    expect(user.created).toBe(true);
     expect(user.name).toEqual('susan');
   });
 });

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -67,6 +67,37 @@ describe('factory.create', () => {
   });
 });
 
+describe('factory.createList', () => {
+  it('creates a list of objects with the specified properties', async () => {
+    const promise = userFactory.createList(2, { name: 'susan' });
+    expect(promise).toBeInstanceOf(Promise);
+
+    const users = await promise;
+    expect(users.length).toBe(2);
+    expect(users[0].id).not.toEqual(users[1].id);
+    expect(users.map(u => u.name)).toEqual(['susan', 'susan']);
+  });
+
+  it('calls onCreate for each item', async () => {
+    const onCreateFn = jest.fn(user => {
+      user.name = 'Bill';
+      return Promise.resolve(user);
+    });
+
+    const factory = Factory.define<User>(({ onCreate }) => {
+      onCreate(onCreateFn);
+      return { id: '1', name: 'Ralph' };
+    });
+
+    const promise = factory.createList(2, { name: 'susan' });
+    expect(promise).toBeInstanceOf(Promise);
+
+    const users = await promise;
+    expect(users.every(u => u.name === 'Bill')).toBeTruthy();
+    expect(onCreateFn).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('afterBuild', () => {
   it('passes the object for manipulation', () => {
     const factory = Factory.define<User>(({ afterBuild }) => {

--- a/lib/__tests__/sample-app/factories/user.ts
+++ b/lib/__tests__/sample-app/factories/user.ts
@@ -3,15 +3,21 @@ import { User } from '../types';
 import postFactory from './post';
 
 const userFactory = Factory.define<User>(
-  ({ associations, sequence, afterBuild }) => {
+  ({ associations, sequence, afterBuild, onCreate }) => {
     afterBuild(user => {
       if (!user.posts.length) {
         user.posts = postFactory.buildList(1, {}, { associations: { user } });
       }
     });
 
+    onCreate(user => {
+      user.created = true;
+      return Promise.resolve(user);
+    })
+
     return {
       id: `user-${sequence}`,
+      created: false,
       name: 'Bob',
       posts: associations.posts || [],
     };

--- a/lib/__tests__/sample-app/factories/user.ts
+++ b/lib/__tests__/sample-app/factories/user.ts
@@ -13,7 +13,7 @@ const userFactory = Factory.define<User>(
     onCreate(user => {
       user.created = true;
       return Promise.resolve(user);
-    })
+    });
 
     return {
       id: `user-${sequence}`,

--- a/lib/__tests__/sample-app/types.ts
+++ b/lib/__tests__/sample-app/types.ts
@@ -1,5 +1,6 @@
 export interface User {
   id: string;
+  created: boolean;
   name: string;
   posts: Post[];
 }

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -4,6 +4,7 @@ import {
   BuildOptions,
   GeneratorFnOptions,
   HookFn,
+  CreateFn,
 } from './types';
 import { FactoryBuilder } from './builder';
 
@@ -12,6 +13,7 @@ const SEQUENCE_START_VALUE = 1;
 export class Factory<T, I = any> {
   private nextId: number = SEQUENCE_START_VALUE;
   private _afterBuilds: HookFn<T>[] = [];
+  private _onCreates: CreateFn<T>[] = [];
   private _associations: Partial<T> = {};
   private _params: DeepPartial<T> = {};
   private _transient: Partial<I> = {};
@@ -25,6 +27,7 @@ export class Factory<T, I = any> {
    * `register` before use.
    * @template T The object the factory builds
    * @template I The transient parameters that your factory supports
+   * @template C The class of the factory object being created.
    * @param generator - your factory function
    */
   static define<T, I = any, C = Factory<T, I>>(
@@ -40,14 +43,7 @@ export class Factory<T, I = any> {
    * @param options
    */
   build(params: DeepPartial<T> = {}, options: BuildOptions<T, I> = {}): T {
-    return new FactoryBuilder<T, I>(
-      this.generator,
-      this.sequence(),
-      { ...this._params, ...params },
-      { ...this._transient, ...options.transient },
-      { ...this._associations, ...options.associations },
-      this._afterBuilds,
-    ).build();
+    return this.builder(params, options).build();
   }
 
   buildList(
@@ -64,6 +60,31 @@ export class Factory<T, I = any> {
   }
 
   /**
+   * Asynchronously create an object using your factory.
+   * @param params
+   * @param options
+   */
+  async create(
+    params: DeepPartial<T> = {},
+    options: BuildOptions<T, I> = {},
+  ): Promise<T> {
+    return this.builder(params, options).create();
+  }
+
+  async createList(
+    number: number,
+    params: DeepPartial<T> = {},
+    options: BuildOptions<T, I> = {},
+  ): Promise<T[]> {
+    let list: Promise<T>[] = [];
+    for (let i = 0; i < number; i++) {
+      list.push(this.create(params, options));
+    }
+
+    return Promise.all(list);
+  }
+
+  /**
    * Extend the factory by adding a function to be called after an object is built.
    * @param afterBuildFn - the function to call. It accepts your object of type T. The value this function returns gets returned from "build"
    * @returns a new factory
@@ -71,6 +92,17 @@ export class Factory<T, I = any> {
   afterBuild(afterBuildFn: HookFn<T>): this {
     const factory = this.clone();
     factory._afterBuilds.push(afterBuildFn);
+    return factory;
+  }
+
+  /**
+   * Extend the factory by adding a function to be called on creation.
+   * @param onCreateFn - The function to call. IT accepts your object of type T. The value this function returns gets returned from "create"
+   * @return a new factory
+   */
+  onCreate(onCreateFn: CreateFn<T>): this {
+    const factory = this.clone();
+    factory._onCreates.push(onCreateFn);
     return factory;
   }
 
@@ -124,5 +156,20 @@ export class Factory<T, I = any> {
 
   protected sequence() {
     return this.nextId++;
+  }
+
+  protected builder(
+    params: DeepPartial<T> = {},
+    options: BuildOptions<T, I> = {},
+  ) {
+    return new FactoryBuilder<T, I>(
+      this.generator,
+      this.sequence(),
+      { ...this._params, ...params },
+      { ...this._transient, ...options.transient },
+      { ...this._associations, ...options.associations },
+      this._afterBuilds,
+      this._onCreates,
+    );
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,12 +9,14 @@ export type DeepPartial<T> = {
 export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;
+  onCreate: (fn: CreateFn<T>) => any;
   params: DeepPartial<T>;
   associations: Partial<T>;
   transientParams: Partial<I>;
 };
 export type GeneratorFn<T, I> = (opts: GeneratorFnOptions<T, I>) => T;
 export type HookFn<T> = (object: T) => any;
+export type CreateFn<T> = (object: T) => Promise<T>;
 export type BuildOptions<T, I> = {
   associations?: Partial<T>;
   transient?: Partial<I>;


### PR DESCRIPTION
### Background
Technically this is something that developers can already implement themselves by extending the `Factory` class. 

```typescript
class AsyncFactory<T, I> extends Factory<T, I> {
  async create(
    params: DeepPartial<T> = {},
    options: BuildOptions<T, I> = {},
  ): Promise<T> {
    return Promise.resolve(this.build(params, options));
  }
}
```

The caveat here is that TypeScript isn't good at figuring out the type of the child class if you create a new factory child class with generics. You need to jump through hoops in order to get it to work correctly:

- You can manually define `C` when calling `ChildFactory.define()`.
- You can override the static `define` method and change the default type of `C` to `ChildFactory`.
- You can use constructors and ignore the `define` method altogether. 

None of these solutions seem particularly good as I feel like they introduce either fragility or verbosity. The best course in my opinion is that the package itself supports some `create` functionality.

### Solution

This closes #16 more or less the same way as proposed in [the async branch](https://github.com/thoughtbot/fishery/tree/async) that @stevehanson was working on. The main difference is that multiple hooks are supported in the same way that multiple `afterBuild` hooks are.

This simple API is ideal in that it allows developers the flexibility to decide how much complexity they want out of their factory. It will let you do everything from calling an API using `fetch()` to implementing an entire adapter pattern without making the former too complicated.

```typescript
const userFactory = Factory.define<User>({params, onCreate} => {
  onCreate(user => {
      return manager.create(user);
  });
  return { name: 'Christopher' };
});

userFactory.create().then(user => {
  console.log('Hi ' + user.name);
});
```