### PR TITLE
Remove reference to "register" in Factory.define

### DIFF
--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -21,8 +21,7 @@ export class Factory<T, I = any> {
   ) {}
 
   /**
-   * Define a factory. This factory needs to be registered with
-   * `register` before use.
+   * Define a factory.
    * @template T The object the factory builds
    * @template I The transient parameters that your factory supports
    * @param generator - your factory function


### PR DESCRIPTION
👋 

Just went through updating a project from `0.4.x` and noticed that `Factory.define` still mentions factory registration.

This removes the reference from the documentation on that method.