### PR TITLE
Fixing onCreate hooks being left unresolved

### DIFF
--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -65,18 +65,15 @@ export class FactoryBuilder<T, I> {
     });
   }
 
-  _callOnCreates(object: T): Promise<T> {
-    const created = Promise.resolve(object);
-
-    this.onCreates.forEach(onCreate => {
+  async _callOnCreates(object: T): Promise<T> {
+    for (const onCreate of this.onCreates) {
       if (typeof onCreate === 'function') {
-        created.then(onCreate);
+        object = await onCreate(object);
       } else {
         throw new Error('"onCreate" must be a function');
       }
-    });
-
-    return created;
+    }
+    return object;
   }
 }
 


### PR DESCRIPTION
This fixes a significant issue introduced in #40.

The purpose of onCreate() hooks is to allow users to run asynchronous code (ex. saving a model to a database).

However, the current implementation does not resolve the onCreate() hooks, which means that code like the following is still impossible to test:

```
test('Gets the correct user', async () => {
  await userFactory.create();
  const user = await User.query().findById(1); // Will not find the user, because userFactory.create() resolves without waiting for .then() functions to resolve
  expect(user.id).toBe(1);
});
```

Additionally, if the onCreate() hook throws an exception, it does not catch that exception which leaves dangling promise rejections.

This PR fixes both issues.﻿
