### PR TITLE
Handle onCreate hook chaining and promise rejections properly

### DIFF
--- a/lib/__tests__/factory-builders.test.ts
+++ b/lib/__tests__/factory-builders.test.ts
@@ -148,6 +148,32 @@ describe('onCreate', () => {
     expect(onCreateGenerator).toHaveBeenCalledTimes(1);
     expect(onCreateBuilder).toHaveBeenCalledTimes(1);
   });
+
+  it('chains return values from onCreate hooks', async () => {
+    const onCreate1 = jest.fn(async user => {
+      return Promise.resolve(userFactory.build({ id: 'onCreate1' }));
+    });
+    const onCreate2 = jest.fn(async user => {
+      user.firstName = 'onCreate2';
+      return Promise.resolve(user);
+    });
+    const user = await userFactory
+      .onCreate(onCreate1)
+      .onCreate(onCreate2)
+      .create();
+    expect(user.id).toEqual('onCreate1');
+    expect(user.firstName).toEqual('onCreate2');
+  });
+
+  it('rejections are handled', async () => {
+    const onCreate = jest.fn(async user => {
+      user.id = 'rejection';
+      return Promise.reject(user);
+    });
+    await expect(
+      userFactory.onCreate(onCreate).create(),
+    ).rejects.toMatchObject({ id: 'rejection' });
+  });
 });
 
 describe('associations', () => {

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -66,11 +66,11 @@ export class FactoryBuilder<T, I> {
   }
 
   _callOnCreates(object: T): Promise<T> {
-    const created = Promise.resolve(object);
+    let created = Promise.resolve(object);
 
     this.onCreates.forEach(onCreate => {
       if (typeof onCreate === 'function') {
-        created.then(onCreate);
+        created = created.then(onCreate);
       } else {
         throw new Error('"onCreate" must be a function');
       }


### PR DESCRIPTION
Simplified version of #45 

Both of the tests fail if the promises are discarded as @ObliviousHarmony spotted out in the comments. 