### PR TITLE
Fix issue where afterBuild, onCreate modifying factory

### DIFF
--- a/lib/__tests__/factory-builders.test.ts
+++ b/lib/__tests__/factory-builders.test.ts
@@ -95,6 +95,17 @@ describe('afterBuild', () => {
     expect(afterBuildGenerator).toHaveBeenCalledTimes(1);
     expect(afterBuildBuilder).toHaveBeenCalledTimes(1);
   });
+
+  it('does not modify the original factory', async () => {
+    const afterBuild = (user: User) => {
+      user.id = 'afterBuild';
+      return user;
+    };
+
+    userFactory.afterBuild(afterBuild);
+    const user = userFactory.build();
+    expect(user.id).toEqual('1');
+  });
 });
 
 describe('onCreate', () => {
@@ -147,6 +158,17 @@ describe('onCreate', () => {
     expect(user.id).toEqual('builder');
     expect(onCreateGenerator).toHaveBeenCalledTimes(1);
     expect(onCreateBuilder).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not modify the original factory', async () => {
+    const onCreate = (user: User) => {
+      user.id = 'onCreate';
+      return Promise.resolve(user);
+    };
+
+    userFactory.onCreate(onCreate);
+    const user = await userFactory.create();
+    expect(user.id).toEqual('1');
   });
 
   it('chains return values from onCreate hooks', async () => {

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -150,6 +150,8 @@ export class Factory<T, I = any> {
       new (generator: GeneratorFn<T, I>): C;
     })(this.generator);
     Object.assign(copy, this);
+    copy._onCreates = [...this._onCreates];
+    copy._afterBuilds = [...this._afterBuilds];
     return copy;
   }
 


### PR DESCRIPTION
Factories are intended to be immutable, but the afterBuild and onCreate builder functions were mutating the factory instead of only adding these functions to the new factory that is returned.

This also fixes the test failure on master after merging #46.