### PR TITLE
Share sequence between extended factories

### DIFF
--- a/lib/__tests__/factory.sequence.test.ts
+++ b/lib/__tests__/factory.sequence.test.ts
@@ -1,0 +1,44 @@
+import { Factory } from 'fishery';
+
+describe('sequence', () => {
+  it('increments by one on build', () => {
+    const userFactory = Factory.define<number>(({ sequence }) => sequence);
+    expect(userFactory.build()).toEqual(1);
+    expect(userFactory.build()).toEqual(2);
+  });
+
+  it('increments on buildList for each item', () => {
+    const userFactory = Factory.define<number>(({ sequence }) => sequence);
+    expect(userFactory.buildList(2)).toEqual([1, 2]);
+    expect(userFactory.build()).toEqual(3);
+  });
+
+  describe('when the factory is extended', () => {
+    it('shares the sequence with the original factory', () => {
+      const userFactory = Factory.define<{ id: number }>(({ sequence }) => ({
+        id: sequence,
+      }));
+      const adminFactory = userFactory.params({});
+      expect(adminFactory.build().id).toEqual(1);
+      expect(userFactory.build().id).toEqual(2);
+      expect(adminFactory.build().id).toEqual(3);
+    });
+  });
+
+  describe('rewindSequence', () => {
+    it('sets sequence back to one after build', () => {
+      const factory = Factory.define<number>(({ sequence }) => sequence);
+      expect(factory.build()).toEqual(1);
+      factory.rewindSequence();
+      expect(factory.build()).toEqual(1);
+      expect(factory.build()).toEqual(2);
+    });
+
+    it('sets sequence back to one after buildList', () => {
+      const factory = Factory.define<number>(({ sequence }) => sequence);
+      expect(factory.buildList(2)).toEqual([1, 2]);
+      factory.rewindSequence();
+      expect(factory.buildList(2)).toEqual([1, 2]);
+    });
+  });
+});

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -154,38 +154,6 @@ describe('onCreate', () => {
   });
 });
 
-describe('factory.rewindSequence', () => {
-  it('sets sequence back to one after build', () => {
-    const factory = Factory.define<User>(({ sequence }) => {
-      return { id: `user-${sequence}`, name: 'Ralph' };
-    });
-
-    expect(factory.build().id).toBe('user-1');
-
-    factory.rewindSequence();
-    expect(factory.build().id).toBe('user-1');
-    expect(factory.build().id).toBe('user-2');
-  });
-
-  it('sets sequence back to one after buildList', () => {
-    const factory = Factory.define<User>(({ sequence }) => {
-      return { id: `user-${sequence}`, name: 'Ralph' };
-    });
-
-    expect(factory.buildList(2)).toEqual([
-      { id: 'user-1', name: 'Ralph' },
-      { id: 'user-2', name: 'Ralph' },
-    ]);
-
-    factory.rewindSequence();
-
-    expect(factory.buildList(2)).toEqual([
-      { id: 'user-1', name: 'Ralph' },
-      { id: 'user-2', name: 'Ralph' },
-    ]);
-  });
-});
-
 describe('merging params', () => {
   describe('factory.tuples', () => {
     const tupleFactory = Factory.define<{ items: [string] }>(() => ({

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -11,7 +11,9 @@ import { FactoryBuilder } from './builder';
 const SEQUENCE_START_VALUE = 1;
 
 export class Factory<T, I = any> {
-  private nextId: number = SEQUENCE_START_VALUE;
+  // id is an object so it is shared between extended factories
+  private id: { value: number } = { value: SEQUENCE_START_VALUE };
+
   private _afterBuilds: HookFn<T>[] = [];
   private _onCreates: CreateFn<T>[] = [];
   private _associations: Partial<T> = {};
@@ -142,7 +144,7 @@ export class Factory<T, I = any> {
    * Sets sequence back to its default value
    */
   rewindSequence() {
-    this.nextId = SEQUENCE_START_VALUE;
+    this.id.value = SEQUENCE_START_VALUE;
   }
 
   protected clone<C extends Factory<T, I>>(this: C): C {
@@ -156,7 +158,7 @@ export class Factory<T, I = any> {
   }
 
   protected sequence() {
-    return this.nextId++;
+    return this.id.value++;
   }
 
   protected builder(


### PR DESCRIPTION
This fixes an issue where using factory extension methods causes the `sequence`s to diverge and be independent. Since the extension methods are the core building blocks for "traits", which are intended to provide syntax sugar for building objects, this behavior is unexpected.

An example of the problem:

```typescript
class UserFactory extends Factory<User> {
  admin() {
    return this.params({ admin: true });
  }
}
const userFactory = UserFactory.define({ sequence }) => {
  return {
    id: sequence,
    admin: false,
  };
});

userFactory.build().id // 1
userFactory.admin().build().id // 2 -- correct, picks up at same spot as userFactory
userFactory.build().id // 2 -- incorrect, since `admin()` generated a new factory that does not share sequence
```

Closes #49 