### PR TITLE
Deep merge params when supplied via traits

### DIFF
--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -155,6 +155,45 @@ describe('onCreate', () => {
 });
 
 describe('merging params', () => {
+  describe('nested objects', () => {
+    type User = {
+      attributes: {
+        registered: boolean;
+        admin?: boolean;
+      };
+    };
+
+    it('preserves nested objects when merging trait-supplied params with build()-supplied', () => {
+      const userFactory = Factory.define<User>(() => ({
+        attributes: { registered: true },
+      }));
+
+      const user = userFactory
+        .params({ attributes: { admin: true } })
+        .build({ attributes: { registered: false } });
+
+      expect(user.attributes).toMatchObject({
+        admin: true,
+        registered: false,
+      });
+    });
+
+    it('preserves nested objects when merging trait-supplied params into each other', () => {
+      const userFactory = Factory.define<User>(() => ({
+        attributes: { registered: true },
+      }));
+      const user = userFactory
+        .params({ attributes: { admin: true } })
+        .params({ attributes: { registered: false } })
+        .build({ attributes: { registered: false } });
+
+      expect(user.attributes).toMatchObject({
+        admin: true,
+        registered: false,
+      });
+    });
+  });
+
   describe('factory.tuples', () => {
     const tupleFactory = Factory.define<{ items: [string] }>(() => ({
       items: ['STRING'],

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -6,6 +6,7 @@ import {
   CreateFn,
 } from './types';
 import mergeWith from 'lodash.mergewith';
+import { merge, mergeCustomizer } from './merge';
 
 export class FactoryBuilder<T, I> {
   constructor(
@@ -52,7 +53,7 @@ export class FactoryBuilder<T, I> {
   // vs DeepPartial<T>) so can do the following in a factory:
   // `user: associations.user || userFactory.build()`
   _mergeParamsOntoObject(object: T) {
-    mergeWith(object, this.params, this.associations, mergeCustomizer);
+    merge(object, this.params, this.associations, mergeCustomizer);
   }
 
   _callAfterBuilds(object: T) {
@@ -79,9 +80,3 @@ export class FactoryBuilder<T, I> {
     return created;
   }
 }
-
-const mergeCustomizer = (_object: any, srcVal: any) => {
-  if (Array.isArray(srcVal)) {
-    return srcVal;
-  }
-};

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -7,6 +7,7 @@ import {
   CreateFn,
 } from './types';
 import { FactoryBuilder } from './builder';
+import { merge, mergeCustomizer } from './merge';
 
 const SEQUENCE_START_VALUE = 1;
 
@@ -125,7 +126,7 @@ export class Factory<T, I = any> {
    */
   params(params: DeepPartial<T>): this {
     const factory = this.clone();
-    factory._params = { ...this._params, ...params };
+    factory._params = merge({}, this._params, params, mergeCustomizer);
     return factory;
   }
 
@@ -168,7 +169,7 @@ export class Factory<T, I = any> {
     return new FactoryBuilder<T, I>(
       this.generator,
       this.sequence(),
-      { ...this._params, ...params },
+      merge({}, this._params, params, mergeCustomizer),
       { ...this._transient, ...options.transient },
       { ...this._associations, ...options.associations },
       this._afterBuilds,

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -1,0 +1,8 @@
+import mergeWith from 'lodash.mergewith';
+
+export const merge = mergeWith;
+export const mergeCustomizer = (_object: any, srcVal: any) => {
+  if (Array.isArray(srcVal)) {
+    return srcVal;
+  }
+};


### PR DESCRIPTION
Previously, deep merge was only being done when merging the params supplied to `build()` on top of the object defined in the factory definition.

This makes it so a deep merge is also performed when merging the `params` supplied to `params()` into the params supplied to `build()` and also when merging params from multiple `params()` calls into each other.

closes #54