### PR TITLE
Preserve the object passed to build function

### DIFF
--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -3,6 +3,8 @@ import { CreateFn, Factory, HookFn } from 'fishery';
 type User = {
   id: string;
   name: string;
+  age?: number;
+  email?: string | null;
   address?: { city: string; state: string };
 };
 
@@ -24,6 +26,22 @@ describe('factory.build', () => {
     expect(user.id).not.toBeNull();
     expect(user.name).toEqual('susan');
     expect(user.address?.state).toEqual('MI');
+  });
+
+  it('builds the object for optional undefined keys', () => {
+    const user = userFactory.build({ name: 'susan', age: undefined });
+    expect(user.age).toBeUndefined();
+  });
+
+  it('builds the object for optional keys', () => {
+    const user = userFactory.build({ name: 'susan', age: 40, email: 'person@example.com' });
+    expect(user.age).toBe(40);
+    expect(user.email).toBe('person@example.com');
+  });
+
+  it('builds the object for optional null keys', () => {
+    const user = userFactory.build({ name: 'susan', email: null });
+    expect(user.email).toBeNull();
   });
 
   it('accepts partials of nested objects', () => {

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -34,7 +34,11 @@ describe('factory.build', () => {
   });
 
   it('builds the object for optional keys', () => {
-    const user = userFactory.build({ name: 'susan', age: 40, email: 'person@example.com' });
+    const user = userFactory.build({
+      name: 'susan',
+      age: 40,
+      email: 'person@example.com',
+    });
     expect(user.age).toBe(40);
     expect(user.email).toBe('person@example.com');
   });

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -4,8 +4,14 @@ type User = {
   id: string;
   name: string;
   age?: number;
+  isMajor?: boolean;
   email?: string | null;
   address?: { city: string; state: string };
+};
+
+type Device = {
+  platform: string;
+  isTablet: boolean | null;
 };
 
 const userFactory = Factory.define<User>(({ sequence }) => {
@@ -13,10 +19,18 @@ const userFactory = Factory.define<User>(({ sequence }) => {
   return {
     id: `user-${sequence}`,
     name,
+    isMajor: false,
     address: {
       city: 'Detroit',
       state: 'MI',
     },
+  };
+});
+
+const deviceFactory = Factory.define<Device>(() => {
+  return {
+    platform: 'iOS',
+    isTablet: null,
   };
 });
 
@@ -31,6 +45,16 @@ describe('factory.build', () => {
   it('builds the object for optional undefined keys', () => {
     const user = userFactory.build({ name: 'susan', age: undefined });
     expect(user.age).toBeUndefined();
+  });
+
+  it('builds the object when existing false keys are overridden', () => {
+    const user = userFactory.build({ name: 'susan', isMajor: undefined });
+    expect(user.isMajor).toBeUndefined();
+  });
+
+  it('builds the object when existing null keys are overridden', () => {
+    const device = deviceFactory.build({ isTablet: undefined });
+    expect(device.isTablet).toBeUndefined();
   });
 
   it('builds the object for optional keys', () => {

--- a/lib/__tests__/factory.test.ts
+++ b/lib/__tests__/factory.test.ts
@@ -3,15 +3,7 @@ import { CreateFn, Factory, HookFn } from 'fishery';
 type User = {
   id: string;
   name: string;
-  age?: number;
-  isMajor?: boolean;
-  email?: string | null;
   address?: { city: string; state: string };
-};
-
-type Device = {
-  platform: string;
-  isTablet: boolean | null;
 };
 
 const userFactory = Factory.define<User>(({ sequence }) => {
@@ -19,18 +11,10 @@ const userFactory = Factory.define<User>(({ sequence }) => {
   return {
     id: `user-${sequence}`,
     name,
-    isMajor: false,
     address: {
       city: 'Detroit',
       state: 'MI',
     },
-  };
-});
-
-const deviceFactory = Factory.define<Device>(() => {
-  return {
-    platform: 'iOS',
-    isTablet: null,
   };
 });
 
@@ -40,36 +24,6 @@ describe('factory.build', () => {
     expect(user.id).not.toBeNull();
     expect(user.name).toEqual('susan');
     expect(user.address?.state).toEqual('MI');
-  });
-
-  it('builds the object for optional undefined keys', () => {
-    const user = userFactory.build({ name: 'susan', age: undefined });
-    expect(user.age).toBeUndefined();
-  });
-
-  it('builds the object when existing false keys are overridden', () => {
-    const user = userFactory.build({ name: 'susan', isMajor: undefined });
-    expect(user.isMajor).toBeUndefined();
-  });
-
-  it('builds the object when existing null keys are overridden', () => {
-    const device = deviceFactory.build({ isTablet: undefined });
-    expect(device.isTablet).toBeUndefined();
-  });
-
-  it('builds the object for optional keys', () => {
-    const user = userFactory.build({
-      name: 'susan',
-      age: 40,
-      email: 'person@example.com',
-    });
-    expect(user.age).toBe(40);
-    expect(user.email).toBe('person@example.com');
-  });
-
-  it('builds the object for optional null keys', () => {
-    const user = userFactory.build({ name: 'susan', email: null });
-    expect(user.email).toBeNull();
   });
 
   it('accepts partials of nested objects', () => {
@@ -196,175 +150,6 @@ describe('onCreate', () => {
       return expect(factory.create()).rejects.toThrowError(
         /must be a function/,
       );
-    });
-  });
-});
-
-describe('merging params', () => {
-  describe('nested objects', () => {
-    type User = {
-      attributes: {
-        registered: boolean;
-        admin?: boolean;
-      };
-    };
-
-    it('preserves nested objects when merging trait-supplied params with build()-supplied', () => {
-      const userFactory = Factory.define<User>(() => ({
-        attributes: { registered: true },
-      }));
-
-      const user = userFactory
-        .params({ attributes: { admin: true } })
-        .build({ attributes: { registered: false } });
-
-      expect(user.attributes).toMatchObject({
-        admin: true,
-        registered: false,
-      });
-    });
-
-    it('preserves nested objects when merging trait-supplied params into each other', () => {
-      const userFactory = Factory.define<User>(() => ({
-        attributes: { registered: true },
-      }));
-      const user = userFactory
-        .params({ attributes: { admin: true } })
-        .params({ attributes: { registered: false } })
-        .build({ attributes: { registered: false } });
-
-      expect(user.attributes).toMatchObject({
-        admin: true,
-        registered: false,
-      });
-    });
-  });
-
-  describe('factory.tuples', () => {
-    const tupleFactory = Factory.define<{ items: [string] }>(() => ({
-      items: ['STRING'],
-    }));
-
-    it('builds a tuple with default value', () => {
-      expect(tupleFactory.build().items).toEqual(['STRING']);
-    });
-
-    it('generates a compile error when tuple not defined', () => {
-      // @ts-expect-error
-      tupleFactory.build({ items: [] });
-    });
-
-    it('overrides the tuple when passed to build', () => {
-      expect(
-        Factory.define<[string]>(() => ['STRING']).build(['VALUE']),
-      ).toEqual(['VALUE']);
-    });
-  });
-
-  describe('factory.arrays', () => {
-    const arrayFactory = Factory.define<{ items: string[] }>(() => ({
-      items: ['STRING'],
-    }));
-
-    it('builds an empty array of strings', () => {
-      expect(arrayFactory.build({ items: [] }).items).toEqual([]);
-    });
-
-    it('builds a non-empty array of string', () => {
-      expect(arrayFactory.build().items).toEqual(['STRING']);
-    });
-
-    it('overrides the array', () => {
-      expect(arrayFactory.build({ items: ['VALUE'] }).items).toEqual(['VALUE']);
-    });
-
-    it('doesnt allow passing a partial of an array object', () => {
-      type User = {
-        id: string;
-        name: string;
-      };
-
-      const arrayFactory = Factory.define<{ users: User[] }>(() => ({
-        users: [{ id: '1', name: 'Oscar' }],
-      }));
-
-      // @ts-expect-error
-      arrayFactory.build({ users: [{ id: '2' }] });
-    });
-
-    it('correctly types "params" in the factory to the full array with no compiler error', () => {
-      Factory.define<{ items: string[] }>(({ params }) => ({
-        items: params.items || ['hello'],
-      }));
-    });
-  });
-
-  describe('factories.unknown', () => {
-    it('does not generate compiler error for unknown', () => {
-      interface User {
-        something: unknown;
-        somethingOptional?: unknown;
-      }
-
-      const userFactory = Factory.define<User>(() => ({
-        something: 'blah',
-      }));
-
-      userFactory.build({ something: 1, somethingOptional: 'sdf' });
-      userFactory.build();
-    });
-
-    it('does not generate compiler error with unknown inside of arrays', () => {
-      interface Entity1 {
-        entity2: Entity2;
-      }
-
-      interface Entity2 {
-        id: string;
-        entity3: Array<Entity3>;
-        entity3Optional?: Array<Entity3>;
-      }
-
-      interface Entity3 {
-        _permissions: unknown;
-      }
-
-      const entity2Factory = Factory.define<Entity2>(() => ({
-        id: 'abc',
-        entity3: [],
-        entity3Optional: [],
-      }));
-
-      const entity2 = entity2Factory.build();
-
-      const entity1Factory = Factory.define<Entity1>(() => ({
-        entity2: entity2Factory.build(),
-      }));
-
-      entity1Factory.build({ entity2: entity2 });
-    });
-
-    it('does not generate compiler error with unknown nested in object', () => {
-      interface Entity1 {
-        entity2: Entity2;
-      }
-
-      interface Entity2 {
-        entity3: { _permissions: unknown };
-      }
-
-      const entity2Factory = Factory.define<Entity2>(() => ({
-        id: 'abc',
-        entity3: { _permissions: 'foo' },
-      }));
-
-      const entity2 = entity2Factory.build();
-
-      const entity1Factory = Factory.define<Entity1>(() => ({
-        entity2: entity2Factory.build(),
-      }));
-
-      entity1Factory.build({ entity2 });
     });
   });
 });

--- a/lib/__tests__/merge-params.test.ts
+++ b/lib/__tests__/merge-params.test.ts
@@ -1,0 +1,200 @@
+import { Factory } from 'fishery';
+
+describe('merging params', () => {
+  describe('nested objects', () => {
+    type User = {
+      attributes: {
+        registered: boolean;
+        admin?: boolean;
+      };
+    };
+
+    it('preserves nested objects when merging trait-supplied params with build()-supplied', () => {
+      const userFactory = Factory.define<User>(() => ({
+        attributes: { registered: true },
+      }));
+
+      const user = userFactory
+        .params({ attributes: { admin: true } })
+        .build({ attributes: { registered: false } });
+
+      expect(user.attributes).toMatchObject({
+        admin: true,
+        registered: false,
+      });
+    });
+
+    it('preserves nested objects when merging trait-supplied params into each other', () => {
+      const userFactory = Factory.define<User>(() => ({
+        attributes: { registered: true },
+      }));
+      const user = userFactory
+        .params({ attributes: { admin: true } })
+        .params({ attributes: { registered: false } })
+        .build({ attributes: { registered: false } });
+
+      expect(user.attributes).toMatchObject({
+        admin: true,
+        registered: false,
+      });
+    });
+  });
+
+  describe('factory.tuples', () => {
+    const tupleFactory = Factory.define<{ items: [string] }>(() => ({
+      items: ['STRING'],
+    }));
+
+    it('builds a tuple with default value', () => {
+      expect(tupleFactory.build().items).toEqual(['STRING']);
+    });
+
+    it('generates a compile error when tuple not defined', () => {
+      // @ts-expect-error
+      tupleFactory.build({ items: [] });
+    });
+
+    it('overrides the tuple when passed to build', () => {
+      expect(
+        Factory.define<[string]>(() => ['STRING']).build(['VALUE']),
+      ).toEqual(['VALUE']);
+    });
+  });
+
+  describe('factory.arrays', () => {
+    const arrayFactory = Factory.define<{ items: string[] }>(() => ({
+      items: ['STRING'],
+    }));
+
+    it('builds an empty array of strings', () => {
+      expect(arrayFactory.build({ items: [] }).items).toEqual([]);
+    });
+
+    it('builds a non-empty array of string', () => {
+      expect(arrayFactory.build().items).toEqual(['STRING']);
+    });
+
+    it('overrides the array', () => {
+      expect(arrayFactory.build({ items: ['VALUE'] }).items).toEqual(['VALUE']);
+    });
+
+    it('doesnt allow passing a partial of an array object', () => {
+      type User = {
+        id: string;
+        name: string;
+      };
+
+      const arrayFactory = Factory.define<{ users: User[] }>(() => ({
+        users: [{ id: '1', name: 'Oscar' }],
+      }));
+
+      // @ts-expect-error
+      arrayFactory.build({ users: [{ id: '2' }] });
+    });
+
+    it('correctly types "params" in the factory to the full array with no compiler error', () => {
+      Factory.define<{ items: string[] }>(({ params }) => ({
+        items: params.items || ['hello'],
+      }));
+    });
+  });
+
+  describe('factories.undefined', () => {
+    it('overrides the initial value', () => {
+      type User = { name?: string };
+      const userFactory = Factory.define<User>(() => ({ name: 'Ann' }));
+      expect(userFactory.build({ name: undefined }).name).toBeUndefined();
+    });
+
+    it('overrides an initial falsy value', () => {
+      type User = { registered?: boolean };
+      const userFactory = Factory.define<User>(() => ({ registered: false }));
+      expect(
+        userFactory.build({ registered: undefined }).registered,
+      ).toBeUndefined();
+    });
+
+    it('overrides an initial null value', () => {
+      type User = { registered?: boolean | null };
+      const userFactory = Factory.define<User>(() => ({ registered: null }));
+      expect(
+        userFactory.build({ registered: undefined }).registered,
+      ).toBeUndefined();
+    });
+
+    it('can be overridden by falsy value', () => {
+      type User = { name?: string | null };
+      const userFactory = Factory.define<User>(() => ({ name: undefined }));
+      expect(userFactory.build({ name: null }).name).toBeNull();
+    });
+  });
+
+  describe('factories.unknown', () => {
+    it('does not generate compiler error for unknown', () => {
+      interface User {
+        something: unknown;
+        somethingOptional?: unknown;
+      }
+
+      const userFactory = Factory.define<User>(() => ({
+        something: 'blah',
+      }));
+
+      userFactory.build({ something: 1, somethingOptional: 'sdf' });
+      userFactory.build();
+    });
+
+    it('does not generate compiler error with unknown inside of arrays', () => {
+      interface Entity1 {
+        entity2: Entity2;
+      }
+
+      interface Entity2 {
+        id: string;
+        entity3: Array<Entity3>;
+        entity3Optional?: Array<Entity3>;
+      }
+
+      interface Entity3 {
+        _permissions: unknown;
+      }
+
+      const entity2Factory = Factory.define<Entity2>(() => ({
+        id: 'abc',
+        entity3: [],
+        entity3Optional: [],
+      }));
+
+      const entity2 = entity2Factory.build();
+
+      const entity1Factory = Factory.define<Entity1>(() => ({
+        entity2: entity2Factory.build(),
+      }));
+
+      entity1Factory.build({ entity2: entity2 });
+    });
+
+    it('does not generate compiler error with unknown nested in object', () => {
+      interface Entity1 {
+        entity2: Entity2;
+      }
+
+      interface Entity2 {
+        entity3: { _permissions: unknown };
+      }
+
+      const entity2Factory = Factory.define<Entity2>(() => ({
+        id: 'abc',
+        entity3: { _permissions: 'foo' },
+      }));
+
+      const entity2 = entity2Factory.build();
+
+      const entity1Factory = Factory.define<Entity1>(() => ({
+        entity2: entity2Factory.build(),
+      }));
+
+      entity1Factory.build({ entity2 });
+    });
+  });
+});

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -2,14 +2,14 @@ import mergeWith from 'lodash.mergewith';
 
 export const merge = mergeWith;
 export const mergeCustomizer = (
-  _object: any,
+  objValue: any,
   srcVal: any,
   key: 'string',
   object: any,
 ) => {
   if (Array.isArray(srcVal)) {
     return srcVal;
-  } else if (srcVal === undefined && _object) {
+  } else if (srcVal === undefined) {
     object[key] = srcVal;
   }
 };

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -1,11 +1,15 @@
 import mergeWith from 'lodash.mergewith';
 
 export const merge = mergeWith;
-export const mergeCustomizer = (_object: any, srcVal: any, key: 'string', object: any) => {
+export const mergeCustomizer = (
+  _object: any,
+  srcVal: any,
+  key: 'string',
+  object: any,
+) => {
   if (Array.isArray(srcVal)) {
     return srcVal;
-  }
-  else if (srcVal === undefined && _object) {
-    object[key] = srcVal
+  } else if (srcVal === undefined && _object) {
+    object[key] = srcVal;
   }
 };

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -1,8 +1,11 @@
 import mergeWith from 'lodash.mergewith';
 
 export const merge = mergeWith;
-export const mergeCustomizer = (_object: any, srcVal: any) => {
+export const mergeCustomizer = (_object: any, srcVal: any, key: 'string', object: any) => {
   if (Array.isArray(srcVal)) {
     return srcVal;
+  }
+  else if (srcVal === undefined && _object) {
+    object[key] = srcVal
   }
 };


### PR DESCRIPTION
This PR aims to fix the problem mentioned in this [issue](https://github.com/thoughtbot/fishery/issues/44).

Previously when an object with an explicit property of undefined was passed, it was being ignored and substituted with the object property from the factory definition. This was not the correct behaviour because the passed property of the user was lost.

Now, this is preserved and does not get automatically substituted.

