### PR TITLE
Update fishery to support bulk operations

### DIFF
--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -4,6 +4,7 @@ import {
   GeneratorFnOptions,
   DeepPartial,
   CreateFn,
+  BulkCreateFn,
 } from './types';
 import mergeWith from 'lodash.mergewith';
 import { merge, mergeCustomizer } from './merge';
@@ -17,6 +18,7 @@ export class FactoryBuilder<T, I> {
     private associations: Partial<T>,
     private afterBuilds: HookFn<T>[],
     private onCreates: CreateFn<T>[],
+    private onBulkCreates: BulkCreateFn<T>[],
   ) {}
 
   build() {
@@ -24,6 +26,7 @@ export class FactoryBuilder<T, I> {
       sequence: this.sequence,
       afterBuild: this.setAfterBuild,
       onCreate: this.setOnCreate,
+      onBulkCreate: this.setOnBulkCreate,
       params: this.params,
       associations: this.associations,
       transientParams: this.transientParams,
@@ -47,6 +50,10 @@ export class FactoryBuilder<T, I> {
   setOnCreate = (hook: CreateFn<T>) => {
     this.onCreates = [hook, ...this.onCreates];
   };
+
+  setOnBulkCreate = (hook: BulkCreateFn<T>) => {
+    this.onBulkCreates = [hook, ...this.onBulkCreates];
+  }
 
   // merge params and associations into object. The only reason 'associations'
   // is separated is because it is typed differently from `params` (Partial<T>

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -4,7 +4,6 @@ import {
   GeneratorFnOptions,
   DeepPartial,
   CreateFn,
-  BulkCreateFn,
 } from './types';
 import mergeWith from 'lodash.mergewith';
 import { merge, mergeCustomizer } from './merge';
@@ -18,7 +17,6 @@ export class FactoryBuilder<T, I> {
     private associations: Partial<T>,
     private afterBuilds: HookFn<T>[],
     private onCreates: CreateFn<T>[],
-    private onBulkCreates: BulkCreateFn<T>[],
   ) {}
 
   build() {
@@ -26,7 +24,6 @@ export class FactoryBuilder<T, I> {
       sequence: this.sequence,
       afterBuild: this.setAfterBuild,
       onCreate: this.setOnCreate,
-      onBulkCreate: this.setOnBulkCreate,
       params: this.params,
       associations: this.associations,
       transientParams: this.transientParams,
@@ -50,10 +47,6 @@ export class FactoryBuilder<T, I> {
   setOnCreate = (hook: CreateFn<T>) => {
     this.onCreates = [hook, ...this.onCreates];
   };
-
-  setOnBulkCreate = (hook: BulkCreateFn<T>) => {
-    this.onBulkCreates = [hook, ...this.onBulkCreates];
-  }
 
   // merge params and associations into object. The only reason 'associations'
   // is separated is because it is typed differently from `params` (Partial<T>

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -5,7 +5,6 @@ import {
   GeneratorFnOptions,
   HookFn,
   CreateFn,
-  BulkCreateFn,
 } from './types';
 import { FactoryBuilder } from './builder';
 import { merge, mergeCustomizer } from './merge';
@@ -18,10 +17,10 @@ export class Factory<T, I = any> {
 
   private _afterBuilds: HookFn<T>[] = [];
   private _onCreates: CreateFn<T>[] = [];
+  private _onBulkCreates: CreateFn<T[]>[] = [];
   private _associations: Partial<T> = {};
   private _params: DeepPartial<T> = {};
   private _transient: Partial<I> = {};
-  private _onBulkCreates: BulkCreateFn<T>[] = [];
 
   constructor(
     private readonly generator: (opts: GeneratorFnOptions<T, I>) => T,
@@ -80,16 +79,21 @@ export class Factory<T, I = any> {
     params: DeepPartial<T> = {},
     options: BuildOptions<T, I> = {},
   ): Promise<T[]> {
-    let list: Promise<T>[] = [];
-    for (let i = 0; i < number; i++) {
-      list.push(this.create(params, options));
-    }
+    if (options.bulkCreate) {
+      const objects = this.buildList(number, params, options);
+      return this._callOnBulkCreates(objects)
+    } else  {
+      let list: Promise<T>[] = [];
+      for (let i = 0; i < number; i++) {
+        list.push(this.create(params, options));
+      }
 
-    return Promise.all(list);
+      return Promise.all(list);
+    }
   }
 
-  _callOnBulkCreates(object: T[]): Promise<T[]> {
-    let created = Promise.resolve(object);
+  _callOnBulkCreates(objects: T[]): Promise<T[]> {
+    let created = Promise.resolve(objects);
 
     this._onBulkCreates.forEach(onBulkCreate => {
       if (typeof onBulkCreate === 'function') {
@@ -98,23 +102,8 @@ export class Factory<T, I = any> {
         throw new Error('"onBulkCreate" must be a function');
       }
     });
-    
+
     return created;
-  }
-
-  async bulkCreateList(
-    number: number,
-    params: DeepPartial<T> = {},
-    options: BuildOptions<T, I> = {},
-  ): Promise<T[]> {
-    const list = this.buildList(number, params, options);
-    return this._callOnBulkCreates(list);
-  }
-
-  onBulkCreate(onBulkCreateFn: BulkCreateFn<T>): this {
-    const factory = this.clone();
-    factory._onBulkCreates.push(onBulkCreateFn);
-    return factory;
   }
 
   /**
@@ -136,6 +125,19 @@ export class Factory<T, I = any> {
   onCreate(onCreateFn: CreateFn<T>): this {
     const factory = this.clone();
     factory._onCreates.push(onCreateFn);
+    return factory;
+  }
+
+  /**
+   * Extend the factory by adding a function to be called on bulk creation.
+   * @param onBulkCreateFn - The function to call. IT accepts array of object of type T.
+   * The value this function returns gets returned from "createList" when bulkCreate is true
+   * 
+   * @return a new factory
+   */
+  onBulkCreate(onBulkCreateFn: CreateFn<T[]>): this {
+    const factory = this.clone();
+    factory._onBulkCreates.push(onBulkCreateFn);
     return factory;
   }
 
@@ -205,7 +207,6 @@ export class Factory<T, I = any> {
       { ...this._associations, ...options.associations },
       this._afterBuilds,
       this._onCreates,
-      this._onBulkCreates,
     );
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,7 @@ export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;
   onCreate: (fn: CreateFn<T>) => any;
+  onBulkCreate: (fn: BulkCreateFn<T>) => any;
   params: DeepPartial<T>;
   associations: Partial<T>;
   transientParams: Partial<I>;
@@ -17,6 +18,7 @@ export type GeneratorFnOptions<T, I> = {
 export type GeneratorFn<T, I> = (opts: GeneratorFnOptions<T, I>) => T;
 export type HookFn<T> = (object: T) => any;
 export type CreateFn<T> = (object: T) => Promise<T>;
+export type BulkCreateFn<T> = (object: T[]) => Promise<T[]>;
 export type BuildOptions<T, I> = {
   associations?: Partial<T>;
   transient?: Partial<I>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,6 @@ export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;
   onCreate: (fn: CreateFn<T>) => any;
-  onBulkCreate: (fn: BulkCreateFn<T>) => any;
   params: DeepPartial<T>;
   associations: Partial<T>;
   transientParams: Partial<I>;
@@ -18,8 +17,8 @@ export type GeneratorFnOptions<T, I> = {
 export type GeneratorFn<T, I> = (opts: GeneratorFnOptions<T, I>) => T;
 export type HookFn<T> = (object: T) => any;
 export type CreateFn<T> = (object: T) => Promise<T>;
-export type BulkCreateFn<T> = (object: T[]) => Promise<T[]>;
 export type BuildOptions<T, I> = {
   associations?: Partial<T>;
   transient?: Partial<I>;
+  bulkCreate?: boolean;
 };


### PR DESCRIPTION
We are using fishery to create test data on remote servers via APIs,  and we are using `createList()`, which iterates on each object and calls `onCreate()` method (which hits API) for each object.  Making an API call for each object is inefficient, so we added a bulk-create hook to perform bulk-operations.

Now we are providing support for bulk create, in which it calls the` onBulkCreate() `method (which hits create api only one time for all the objects) if `bulkCreate` flag passes true to `createList()`.

For example:
              `bulkUserFactory.createList(2, { name: 'susan' }, { bulkCreate: true });`