### PR TITLE
Allow specifying different return type for 'create'

### DIFF
--- a/lib/__tests__/helpers/sleep.ts
+++ b/lib/__tests__/helpers/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,17 +6,19 @@ export type DeepPartial<T> = {
     : DeepPartial<T[P]>;
 };
 
-export type GeneratorFnOptions<T, I> = {
+export type GeneratorFnOptions<T, I, C> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;
-  onCreate: (fn: CreateFn<T>) => any;
+  afterCreate: (fn: AfterCreateFn<C>) => any;
+  onCreate: (fn: OnCreateFn<T, C>) => any;
   params: DeepPartial<T>;
   associations: Partial<T>;
   transientParams: Partial<I>;
 };
-export type GeneratorFn<T, I> = (opts: GeneratorFnOptions<T, I>) => T;
+export type GeneratorFn<T, I, C> = (opts: GeneratorFnOptions<T, I, C>) => T;
 export type HookFn<T> = (object: T) => any;
-export type CreateFn<T> = (object: T) => Promise<T>;
+export type OnCreateFn<T, C = T> = (object: T | C) => C | Promise<C>;
+export type AfterCreateFn<C> = (object: C) => C | Promise<C>;
 export type BuildOptions<T, I> = {
   associations?: Partial<T>;
   transient?: Partial<I>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export type GeneratorFnOptions<T, I, C> = {
 };
 export type GeneratorFn<T, I, C> = (opts: GeneratorFnOptions<T, I, C>) => T;
 export type HookFn<T> = (object: T) => any;
-export type OnCreateFn<T, C = T> = (object: T | C) => C | Promise<C>;
+export type OnCreateFn<T, C = T> = (object: T) => C | Promise<C>;
 export type AfterCreateFn<C> = (object: C) => C | Promise<C>;
 export type BuildOptions<T, I> = {
   associations?: Partial<T>;


### PR DESCRIPTION
This adds a third type parameter when defining a factory which represents the return type of `create`. If this type parameter is not specified, `create` returns the same type as `build`.

```typescript
Factory.define<ReturnTypeOfBuild, TransientParamsType, ReturnTypeOfCreate>()
```

Eg:

```typescript
type UserBeforeSave = {
  name: string;
};

type User = {
  name: string;
  id: number;
};

const factory = Factory.define<UserBeforeSave, any, User>(
  ({ onCreate }) => {
    onCreate(async user => {
      return { ...user, id: 2 };
    });

    return { name: 'Ralph' };
  },
);

const user = factory.build(); // UserBeforeSave
const user2 = await factory.create(); // User
```

## Breaking change: only one `onCreate`

Additionally, a breaking change was made so that only one `onCreate` can exist for a factory:

```typescript
// Previous behavior: calls both of the `onCreate`
// New behavior: each `onCreate` replaces the previous
factory.onCreate(async u => u).onCreate(async u => u).create()
```

This change was necessary since `onCreate` went from having the signature of `(object: T) => Promise<T>` to `(object: T) => Promise<C>` (where `T` is the return type of `build` and `C` is the return type of `create`). Due to the type signature, a second `onCreate` would no longer work.

To still support existing behavior, a new `afterCreate` was added with type signature `(object: C) => Promise<C>`. Multiple of these can be defined, and they are called after the `onCreate`. 

```typescript
 const user = await factory
  .onCreate(async u => u) // called first
  .afterCreate(async u => u) // called second
  .afterCreate(async u => u) // called third
  .create();
```

Fixes #53
Fixes #56