### PR TITLE
Don't modify attributes when building

### DIFF
--- a/lib/__tests__/merge-params.test.ts
+++ b/lib/__tests__/merge-params.test.ts
@@ -1,6 +1,24 @@
 import { Factory } from 'fishery';
 
 describe('merging params', () => {
+  it('doesnt mutate the params object', () => {
+    type UserAttrs = { registered: boolean; admin?: boolean };
+    type User = { attributes: UserAttrs };
+
+    const defaultUserAttrs: UserAttrs = { registered: true };
+    const userFactory = Factory.define<User>(() => ({
+      attributes: defaultUserAttrs,
+    }));
+
+    userFactory.build({
+      attributes: { ...defaultUserAttrs, registered: false, admin: true },
+    });
+
+    // not modified by factory
+    expect(defaultUserAttrs.registered).toBe(true);
+    expect(defaultUserAttrs.admin).toBe(undefined);
+  });
+
   describe('nested objects', () => {
     type User = {
       attributes: {

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -71,9 +71,7 @@ export class FactoryBuilder<T, I, C> {
 
     if (Object.getPrototypeOf(object) === Object.prototype) {
       targetObject = {};
-    }
-
-    if (Array.isArray(object)) {
+    } else if (Array.isArray(object)) {
       targetObject = [];
     }
 

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -62,7 +62,7 @@ export class FactoryBuilder<T, I, C> {
   // vs DeepPartial<T>) so can do the following in a factory:
   // `user: associations.user || userFactory.build()`
   _mergeParamsOntoObject(object: T) {
-    merge(object, this.params, this.associations, mergeCustomizer);
+    merge({}, object, this.params, this.associations, mergeCustomizer);
   }
 
   _callAfterBuilds(object: T) {

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -31,8 +31,9 @@ export class FactoryBuilder<T, I, C> {
       transientParams: this.transientParams,
     };
 
-    const object = this.generator(generatorOptions);
-    this._mergeParamsOntoObject(object);
+    const object = this._mergeParamsOntoObject(
+      this.generator(generatorOptions),
+    );
     this._callAfterBuilds(object);
     return object;
   }
@@ -62,7 +63,27 @@ export class FactoryBuilder<T, I, C> {
   // vs DeepPartial<T>) so can do the following in a factory:
   // `user: associations.user || userFactory.build()`
   _mergeParamsOntoObject(object: T) {
-    merge({}, object, this.params, this.associations, mergeCustomizer);
+    if (typeof object !== 'object') {
+      return object;
+    }
+
+    let targetObject: unknown = object;
+
+    if (Object.getPrototypeOf(object) === Object.prototype) {
+      targetObject = {};
+    }
+
+    if (Array.isArray(object)) {
+      targetObject = [];
+    }
+
+    return merge(
+      targetObject,
+      object,
+      this.params,
+      this.associations,
+      mergeCustomizer,
+    );
   }
 
   _callAfterBuilds(object: T) {

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -4,7 +4,7 @@ export const merge = mergeWith;
 export const mergeCustomizer = (
   objValue: any,
   srcVal: any,
-  key: 'string',
+  key: string,
   object: any,
 ) => {
   if (Array.isArray(srcVal)) {


### PR DESCRIPTION
This fixes an issue where `param` objects that are used within a factory were being modified when the factory is built. Closes https://github.com/thoughtbot/fishery/issues/88