### PR TITLE
Fix for Date usage in DeepPartial

### DIFF
--- a/lib/__tests__/sample-app/factories/post.ts
+++ b/lib/__tests__/sample-app/factories/post.ts
@@ -7,6 +7,7 @@ const postFactory: Factory<Post> = Factory.define<Post>(
     id: sequence,
     title: 'A Post',
     user: associations.user || userFactory.build(params.user || {}),
+    createdAt: params.createdAt || new Date(),
   }),
 );
 

--- a/lib/__tests__/sample-app/types.ts
+++ b/lib/__tests__/sample-app/types.ts
@@ -9,4 +9,5 @@ export interface Post {
   id: number;
   title: string;
   user: User | null;
+  createdAt: Date;
 }

--- a/lib/__tests__/types/deepPartial.test-d.ts
+++ b/lib/__tests__/types/deepPartial.test-d.ts
@@ -20,6 +20,8 @@ describe('deepPartial', () => {
       map: Map<string, number>;
       mapNull: Map<string, number> | null;
       readonlyMapNull: ReadonlyMap<string, number> | null;
+      date: Date;
+      dateNull?: Date | null;
     };
 
     type Expected = {
@@ -37,6 +39,8 @@ describe('deepPartial', () => {
       map?: Map<string, number>;
       mapNull?: Map<string, number> | null;
       readonlyMapNull?: ReadonlyMap<string, number> | null;
+      date?: Date;
+      dateNull?: Date | null;
     };
 
     type Actual = DeepPartial<MyType>;

--- a/lib/types/deepPartial.ts
+++ b/lib/types/deepPartial.ts
@@ -12,6 +12,8 @@ export type DeepPartial<T> = T extends Primitive
   ? T
   : T extends ReadonlyMap<any, any>
   ? T
+  : T extends Date
+  ? Date
   : T extends (...args: any[]) => unknown
   ? T | undefined
   : T extends object


### PR DESCRIPTION
Related #93 

Allows objects with `Date` params to be used in factories. Otherwise, you had to mock the entire public interface of `Date`, or pass it through `associations` which was annoying.