### PR TITLE
Add function overload for better buildList and createList types

### DIFF
--- a/lib/__tests__/types/factory.test-d.ts
+++ b/lib/__tests__/types/factory.test-d.ts
@@ -1,0 +1,71 @@
+import { Factory } from 'fishery';
+import { expectType } from 'tsd';
+import { DeepPartial } from 'lib/types';
+
+type Bar = {
+  baz: string;
+};
+
+type Foo = {
+  bar: Bar;
+  baz: number;
+};
+
+const testFactory = Factory.define<Foo>(() => ({
+  bar: {
+    baz: 'foo',
+  },
+  baz: 123,
+}));
+
+describe('factory types', () => {
+  describe('build', () => {
+    it('has correct return type', () => {
+      const buildResult = testFactory.build();
+      expectType<Foo>(buildResult);
+    });
+  });
+
+  describe('buildList', () => {
+    it('returns empty list if amount is 0', () => {
+      const buildResult = testFactory.buildList(0);
+      expectType<never[]>(buildResult);
+    });
+
+    it('returns non-empty list if amount is not 0', () => {
+      const buildResult = testFactory.buildList(3);
+      expectType<[Foo, ...Foo[]]>(buildResult);
+    });
+
+    it('returns general list if amount is not known', () => {
+      const num: number = 3;
+      const buildResult = testFactory.buildList(num);
+      expectType<Foo[]>(buildResult);
+    });
+  });
+
+  describe('create', () => {
+    it('has correct return type', () => {
+      const buildResult = testFactory.create();
+      expectType<Promise<Foo>>(buildResult);
+    });
+  });
+
+  describe('createList', () => {
+    it('resolves empty list if amount is 0', () => {
+      const buildResult = testFactory.createList(0);
+      expectType<Promise<never[]>>(buildResult);
+    });
+
+    it('resolves non-empty list if amount is not 0', () => {
+      const buildResult = testFactory.createList(3);
+      expectType<Promise<[Foo, ...Foo[]]>>(buildResult);
+    });
+
+    it('resolves general list if amount is not known', () => {
+      const num: number = 3;
+      const buildResult = testFactory.createList(num);
+      expectType<Promise<Foo[]>>(buildResult);
+    });
+  });
+});

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -51,6 +51,16 @@ export class Factory<T, I = any, C = T> {
   }
 
   buildList(
+    number: 0,
+    params?: DeepPartial<T>,
+    options?: BuildOptions<T, I>,
+  ): never[];
+  buildList(
+    number: number,
+    params?: DeepPartial<T>,
+    options?: BuildOptions<T, I>,
+  ): [T, ...T[]];
+  buildList(
     number: number,
     params?: DeepPartial<T>,
     options: BuildOptions<T, I> = {},
@@ -75,6 +85,16 @@ export class Factory<T, I = any, C = T> {
     return this.builder(params, options).create();
   }
 
+  async createList(
+    number: 0,
+    params?: DeepPartial<T>,
+    options?: BuildOptions<T, I>,
+  ): Promise<never[]>;
+  async createList(
+    number: number,
+    params?: DeepPartial<T>,
+    options?: BuildOptions<T, I>,
+  ): Promise<[C, ...C[]]>;
   async createList(
     number: number,
     params?: DeepPartial<T>,

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -50,16 +50,11 @@ export class Factory<T, I = any, C = T> {
     return this.builder(params, options).build();
   }
 
-  buildList(
-    number: 0,
+  buildList<N extends number>(
+    number: N,
     params?: DeepPartial<T>,
     options?: BuildOptions<T, I>,
-  ): never[];
-  buildList(
-    number: number,
-    params?: DeepPartial<T>,
-    options?: BuildOptions<T, I>,
-  ): [T, ...T[]];
+  ): number extends N ? T[] : N extends 0 ? never[] : [T, ...T[]];
   buildList(
     number: number,
     params?: DeepPartial<T>,
@@ -85,16 +80,11 @@ export class Factory<T, I = any, C = T> {
     return this.builder(params, options).create();
   }
 
-  async createList(
-    number: 0,
+  async createList<N extends number>(
+    number: N,
     params?: DeepPartial<T>,
     options?: BuildOptions<T, I>,
-  ): Promise<never[]>;
-  async createList(
-    number: number,
-    params?: DeepPartial<T>,
-    options?: BuildOptions<T, I>,
-  ): Promise<[C, ...C[]]>;
+  ): Promise<number extends N ? C[] : N extends 0 ? never[] : [C, ...C[]]>;
   async createList(
     number: number,
     params?: DeepPartial<T>,


### PR DESCRIPTION
Issue: #95 

Add function overloads for `buildList` and `createList` to return `never[]` if the `number` is 0, and otherwise `[T, ...T[]]`.