### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/dynamic-readme.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -432,17 +432,7 @@ Fishery is Copyright © 2021 Stephen Hanson and thoughtbot. It is free
 software, and may be redistributed under the terms specified in the
 [LICENSE](/LICENSE) file.
 
-### About thoughtbot
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->
 
-<img src="https://thoughtbot.com/thoughtbot-logo-for-readmes.svg" width="375" />
-
-Fishery is maintained and funded by thoughtbot, inc.
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
-We love open source software!
-See [our other projects][community] or
-[hire us][hire] to design, develop, and grow your product.
-
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
 [factory_bot]: https://github.com/thoughtbot/factory_bot


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.